### PR TITLE
chore(common): add pull-request title checker

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,18 @@
+on:
+    pull_request:
+        types: [opened, edited, synchronize, reopened]
+
+# https://github.com/amannn/action-semantic-pull-request
+jobs:
+    title-check:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: amannn/action-semantic-pull-request@v5
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              with:
+                  scopes: |
+                      common
+                      story
+                      tool-next
+                  requireScope: true


### PR DESCRIPTION
## What?

This PR adds a GitHub Action to check semantic pull-request titles.

Currently I've added the following scopes:

- common
- story
- tool-next


I didn't put `story-starter` because `starter` sound redundant. And what do you think about `tool-next`?