### PR TITLE
feat(story): add functionality to select / unselect all button

### DIFF
--- a/story-starter/starters/nuxt/components/StoryList.vue
+++ b/story-starter/starters/nuxt/components/StoryList.vue
@@ -74,7 +74,12 @@ const updateStorySelection = (id: number, checked: boolean) => {
 			:unselectAllStories="unselectAllStories"
 		/>
 		<table class="w-full mt-4 overflow-hidden rounded-md table-fixed">
-			<StoryListHeader />
+			<StoryListHeader
+				:stories="data.stories"
+				:isStorySelected="isStorySelected"
+				:selectAll="selectAll"
+				:unselectAll="unselectAll"
+			/>
 			<tbody>
 				<StoryListItem
 					v-for="(story, index) in data.stories"

--- a/story-starter/starters/nuxt/components/StoryListHeader.vue
+++ b/story-starter/starters/nuxt/components/StoryListHeader.vue
@@ -1,20 +1,62 @@
+<script setup lang="ts">
+import type { Story } from '~/types/story';
+
+const props = defineProps<{
+	stories: Story[];
+	isStorySelected: (storyId: number) => boolean;
+	selectAll: () => void;
+	unselectAll: () => void;
+}>();
+
+type Status = 'none' | 'some' | 'all';
+
+const status = computed<Status>(() => {
+	const selectedStoryCount = props.stories.filter((story) =>
+		props.isStorySelected(story.id)
+	).length;
+
+	if (selectedStoryCount === props.stories.length) {
+		return 'all';
+	} else if (selectedStoryCount === 0) {
+		return 'none';
+	} else {
+		return 'some';
+	}
+});
+</script>
+
 <template>
 	<thead class="bg-gray-100">
 		<tr>
 			<th class="flex items-center gap-3">
-				<label class="label">
-					<input
-						class="checkbox checkbox-xs"
-						type="checkbox"
-						id="story-select-all"
-						@change=""
-						:checked="false"
-					/>
-					<label class="sr-only label-text" for="story-select-all"
-						>Toggle All Stories</label
-					>
-				</label>
-				<span>Name</span>
+				<button
+					v-if="status === 'none'"
+					type="button"
+					class="btn btn-sm btn-ghost btn-check"
+					@click="selectAll"
+				>
+					<LucideSquare :size="20" :stroke-width="1" />
+					<span class="sr-only">Select All Stories</span>
+				</button>
+				<button
+					v-else-if="status === 'some'"
+					type="button"
+					class="btn btn-sm btn-ghost btn-check"
+					@click="selectAll"
+				>
+					<LucideMinusSquare :size="20" :stroke-width="1" />
+					<span class="sr-only">Select All Stories</span>
+				</button>
+				<button
+					v-else-if="status === 'all'"
+					type="button"
+					class="btn btn-sm btn-ghost btn-check"
+					@click="unselectAll"
+				>
+					<LucideCheckSquare2 :size="20" :stroke-width="1" />
+					<span class="sr-only">Unselect All Stories</span>
+				</button>
+				<span class="ml-9">Name</span>
 			</th>
 			<th class="w-32">Content Type</th>
 			<th class="w-28">Last Update</th>
@@ -26,5 +68,13 @@
 <style scoped>
 th {
 	@apply font-normal text-sm text-gray-600 text-left p-4;
+}
+
+.btn-check {
+	@apply m-0 py-2 px-0.5 border-0 text-gray-500;
+}
+
+.btn-check:hover {
+	@apply bg-transparent;
 }
 </style>


### PR DESCRIPTION
## What?

This PR adds functionality to select / unselect all button.

StoryListHeader has the following 3 check status:

- `none`: none of stories **_in the current page_** is selected
- `some`: some of stories **_in the current page_** is selected
- `all`: all of stories **_in the current page_** is selected

The buttons for `none` and `some` selects all stories in the current page. The button for `all` unselects all stories in the current page.

https://github.com/storyblok/space-tool-plugins/assets/499898/3003b156-9d73-47d0-adc5-c8a7182293cd



## Why?

JIRA: EXT-

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

## How to test? (optional)

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->
