### PR TITLE
feat(common): add api to update and get space level settings

### DIFF
--- a/space-plugins/nuxt-base/composables/useSettings.ts
+++ b/space-plugins/nuxt-base/composables/useSettings.ts
@@ -1,0 +1,41 @@
+export const useSettings = async () => {
+	//TODO: pagination?
+
+	const { data, pending, error, refresh } = await useFetch('/api/settings');
+
+	const setSettings = async (body: Record<string, string>) => {
+		pending.value = true;
+
+		const mergedSettings = {
+			...data.value,
+			...body,
+		};
+
+		const {
+			data: changedData,
+			error: changedError,
+			pending: changedPending,
+		} = await useFetch('/api/settings', {
+			method: 'POST',
+			body: mergedSettings,
+		});
+
+		if (changedError.value) {
+			error.value = changedError.value;
+		}
+
+		if (changedData.value) {
+			data.value = mergedSettings;
+		}
+
+		pending.value = changedPending.value;
+	};
+
+	return {
+		data,
+		isLoading: pending,
+		error,
+		refresh,
+		setSettings,
+	};
+};

--- a/space-plugins/nuxt-base/server/api/settings.ts
+++ b/space-plugins/nuxt-base/server/api/settings.ts
@@ -1,0 +1,78 @@
+export default defineEventHandler(async (event): Promise<any> => {
+	const { spaceId, accessToken } = event.context.appSession;
+	const appId = env('APP_ID');
+
+	//TODO: guard for none admins
+	const storyblokClient = createStoryblokClient(spaceId, accessToken);
+	if (event.method === 'GET') {
+		//try catch
+		const response = await storyblokClient.getSettings(appId);
+		if (!isAppDetails(response)) {
+			return undefined;
+		}
+
+		return response.app_provision.space_level_settings;
+	}
+
+	if (event.method === 'POST') {
+		//TODO: checkout runValidatedBody
+		//try catch
+		const settings = await readBody(event);
+		if (isKeyValue(settings)) {
+			await storyblokClient.putSettings(appId, settings);
+
+			return 'Settings updated!';
+		}
+	}
+
+	return undefined;
+});
+
+const createStoryblokClient = (spaceId: number, accessToken: string) => {
+	const putSettings = (appId: string, settings: Record<string, string>) =>
+		$fetch(
+			`https://mapi.storyblok.com/v1/spaces/${spaceId}/app_provisions/${appId}`,
+			{
+				method: 'PUT',
+				headers: { Authorization: `bearer ${accessToken}` },
+				body: {
+					space_level_settings: settings,
+				},
+			},
+		);
+
+	const getSettings = (appId: string) =>
+		$fetch(
+			`https://mapi.storyblok.com/v1/spaces/${spaceId}/app_provisions/${appId}`,
+			{
+				method: 'GET',
+				headers: { Authorization: `bearer ${accessToken}` },
+			},
+		);
+
+	return {
+		getSettings,
+		putSettings,
+	};
+};
+
+//TODO: move
+const isAppDetails = (data: unknown): data is AppDetails =>
+	isObject(data) &&
+	'app_provision' in data &&
+	isAppProvisions(data.app_provision);
+
+const isAppProvisions = (data: unknown): data is AppProvisions =>
+	isObject(data) &&
+	'space_level_settings' in data &&
+	isSpaceLevelSettings(data.space_level_settings);
+
+const isSpaceLevelSettings = (data: unknown): data is AppSettings =>
+	isKeyValue(data);
+
+const isObject = (data: unknown): data is object =>
+	typeof data !== undefined && data !== null && typeof data === 'object';
+
+//TODO: more validation
+const isKeyValue = (data: unknown): data is Record<string, string> =>
+	isObject(data);

--- a/space-plugins/nuxt-base/types/app-provisions.ts
+++ b/space-plugins/nuxt-base/types/app-provisions.ts
@@ -1,0 +1,45 @@
+type AppDetails = {
+	app_provision: AppProvisions;
+	app: App;
+	granted: boolean;
+};
+
+type App = {
+	id: number | string;
+	name: string;
+	slug: string;
+	icon: string | null;
+	plan_level: number | null;
+	preview_video: string | null;
+	app_url: null;
+	description: string | null;
+	intro: string | null;
+	screenshot: string | null;
+	status: string;
+	website: string | null;
+	author: string | null;
+	updated_at: string;
+	field_type_ids: number[];
+	embedded_app_url: string | null;
+	dev_embedded_app_url: string | null;
+	dev_oauth_redirect_uri: string | null;
+	in_sidebar: boolean;
+	in_toolbar: boolean;
+	sidebar_icon: string | null;
+	enable_space_settings: boolean;
+};
+
+type AppProvisions = {
+	public_config: null;
+	session: null;
+	slug: string;
+	app_id: number | string;
+	name: string;
+	in_sidebar: boolean;
+	in_toolbar: boolean;
+	sidebar_icon: string | null;
+	enable_space_settings: boolean;
+	space_level_settings: AppSettings;
+};
+
+type AppSettings = Record<string, string>;

--- a/space-plugins/nuxt-starter/layouts/default.vue
+++ b/space-plugins/nuxt-starter/layouts/default.vue
@@ -1,0 +1,16 @@
+<template>
+	<div class="mx-20 my-11">
+		<Header title="Story Starter">
+			<template #icon>
+				<LucideTornado class="text-primary" />
+			</template>
+			<template #description> This is a `space-plugin-nuxt-starter`. </template>
+			<!--			<template #right-action-bar>-->
+			<!--			-->
+			<!--			</template>-->
+		</Header>
+		<div class="mt-10">
+			<slot />
+		</div>
+	</div>
+</template>

--- a/space-plugins/nuxt-starter/pages/index.vue
+++ b/space-plugins/nuxt-starter/pages/index.vue
@@ -1,37 +1,25 @@
 <script setup lang="ts">
+//TODO: check if user is admin
 const { data } = await useFetch('/api/stories');
 </script>
 
 <template>
-	<div>
-		<div class="mx-20 my-11">
-			<Header title="Story Starter">
-				<template #icon>
-					<LucideTornado class="text-primary" />
-				</template>
-				<template #description>
-					This is a `space-plugin-nuxt-starter`.
-				</template>
-				<!-- <template #right-action-bar>
-					<button class="btn btn-outline">
-						<span class="text-base">Settings</span><LucideSettings :size="16" />
-					</button>
-				</template> -->
-			</Header>
+	<NuxtLink class="btn btn-outline" to="/settings">
+		<span class="text-base">Settings</span>
+		<LucideSettings :size="16" />
+	</NuxtLink>
 
-			<div v-if="data">
-				<p class="mt-10 text-sm font-thin text-gray-600">
-					Total number of stories: {{ data.total }}
-				</p>
-				<ul class="mt-4 space-y-4">
-					<li v-for="story in data.stories" :key="story.id">
-						<span class="text-lg">{{ story.name }}</span>
-						<span class="ml-2 text-sm font-thin text-gray-600"
-							>(/{{ story.slug }})</span
-						>
-					</li>
-				</ul>
-			</div>
-		</div>
+	<div v-if="data">
+		<p class="text-sm font-thin text-gray-600">
+			Total number of stories: {{ data.total }}
+		</p>
+		<ul class="mt-4 space-y-4">
+			<li v-for="story in data.stories" :key="story.id">
+				<span class="text-lg">{{ story.name }}</span>
+				<span class="ml-2 text-sm font-thin text-gray-600"
+					>(/{{ story.slug }})</span
+				>
+			</li>
+		</ul>
 	</div>
 </template>

--- a/space-plugins/nuxt-starter/pages/settings.vue
+++ b/space-plugins/nuxt-starter/pages/settings.vue
@@ -1,0 +1,30 @@
+<script setup lang="ts">
+//TODO: typing
+const { data, isLoading, setSettings, refresh, error } = await useSettings();
+const name = ref('');
+
+if (!error.value) {
+	//load settings in initial load
+	name.value = data.value.name;
+}
+
+const onSave = async (name: string) => {
+	await setSettings({
+		name,
+	});
+};
+</script>
+
+<template>
+	<span>Loading {{ isLoading }}</span>
+	<span>Error {{ error }}</span>
+	<button @click="refresh()">refresh</button>
+	<span>Current Settings: {{ JSON.stringify(data) }}}</span>
+	<div>
+		<label for="name" class="label">Name: </label>
+		<input class="input" type="text" name="name" v-model="name" />
+		<button class="btn" @click="onSave(name)" type="submit">Save</button>
+	</div>
+
+	<NuxtLink class="link" to="/">Go back</NuxtLink>
+</template>


### PR DESCRIPTION
## What?
This PR includes additions to both nuxt-base and nuxt-starter to add the setting retrieval and edition. 

### nuxt-base: 
- api/settings (GET, POST) 
- composables/useSettings.ts
- typing

### nuxt-starter:
- settings.vue 
- layouts/default.vue

### Enabling Settings for APP (MAPI not implemented at the moment)
If you wan to test this PR functionality, please make sure to use our Postman Collection (MAPI with OAuth Access Token -> space settings -> PUT enableSettings) together with the personal access token to enable the space level settings for your app otherwise `api/settings` (POST) will not work.



## Why?

[JIRA: EXT-2161](https://storyblok.atlassian.net/browse/EXT-2161)

## How to test? (optional)
1. Make sure to follow instruction from Enabling Settings for APP (not working at the moment) from the above section
2. Make sure to set `APP_ID` inside the .env
3. Make sure to replace <NuxtLink/> `to` query paramaters inside nuxt-starter index.vue and settings.vue 
