### PR TITLE
feat(common): persist query parameters

### DIFF
--- a/space-plugins/nuxt-base/middleware/persist-query.global.ts
+++ b/space-plugins/nuxt-base/middleware/persist-query.global.ts
@@ -1,0 +1,39 @@
+export default defineNuxtRouteMiddleware((to, from) => {
+	if (isValidQuery(from.query) && !isValidQuery(to.query)) {
+		return navigateTo({
+			...to,
+			path: to.path,
+			query: {
+				...to.query,
+				...from.query,
+			},
+		});
+	}
+
+	return;
+});
+
+const isValidQuery = (query: unknown): query is Query =>
+	typeof query === 'object' &&
+	query !== null &&
+	'space_id' in query &&
+	typeof query.space_id === 'string' &&
+	'user_id' in query &&
+	typeof query.user_id === 'string' &&
+	'user_is_admin' in query &&
+	typeof query.user_is_admin === 'string' &&
+	'space_name' in query &&
+	typeof query.space_name === 'string' &&
+	'space_is_trial' in query &&
+	typeof query.space_is_trial === 'string' &&
+	'user_lang' in query &&
+	typeof query.user_lang === 'string';
+
+type Query = {
+	space_id: string;
+	user_id: string;
+	user_is_admin: string;
+	space_name: string;
+	space_is_trial: string;
+	user_lang: string;
+};

--- a/space-plugins/nuxt-base/middleware/persist-query.global.ts
+++ b/space-plugins/nuxt-base/middleware/persist-query.global.ts
@@ -16,18 +16,22 @@ export default defineNuxtRouteMiddleware((to, from) => {
 const isValidQuery = (query: unknown): query is Query =>
 	typeof query === 'object' &&
 	query !== null &&
-	'space_id' in query &&
-	typeof query.space_id === 'string' &&
-	'user_id' in query &&
-	typeof query.user_id === 'string' &&
-	'user_is_admin' in query &&
-	typeof query.user_is_admin === 'string' &&
-	'space_name' in query &&
-	typeof query.space_name === 'string' &&
-	'space_is_trial' in query &&
-	typeof query.space_is_trial === 'string' &&
-	'user_lang' in query &&
-	typeof query.user_lang === 'string';
+	(('space_id' in query &&
+		typeof query.space_id === 'string' &&
+		'user_id' in query &&
+		typeof query.user_id === 'string' &&
+		'user_is_admin' in query &&
+		typeof query.user_is_admin === 'string' &&
+		'space_name' in query &&
+		typeof query.space_name === 'string' &&
+		'space_is_trial' in query &&
+		typeof query.space_is_trial === 'string' &&
+		'user_lang' in query &&
+		typeof query.user_lang === 'string') ||
+		('spaceId' in query &&
+			typeof query.spaceId === 'string' &&
+			'userId' in query &&
+			typeof query.userId === 'string'));
 
 type Query = {
 	space_id: string;

--- a/space-plugins/nuxt-base/middleware/persist-query.global.ts
+++ b/space-plugins/nuxt-base/middleware/persist-query.global.ts
@@ -33,11 +33,16 @@ const isValidQuery = (query: unknown): query is Query =>
 			'userId' in query &&
 			typeof query.userId === 'string'));
 
-type Query = {
-	space_id: string;
-	user_id: string;
-	user_is_admin: string;
-	space_name: string;
-	space_is_trial: string;
-	user_lang: string;
-};
+type Query =
+	| {
+			space_id: string;
+			user_id: string;
+			user_is_admin: string;
+			space_name: string;
+			space_is_trial: string;
+			user_lang: string;
+	  }
+	| {
+			spaceId: string;
+			userId: string;
+	  };


### PR DESCRIPTION
## What?
This PR adds a [middleware](https://nuxt.com/docs/guide/directory-structure/middleware) to the nuxt-base project, which makes sure that essential query parameters are preserved throughout navigation. 

In this case the query parameters that must be preserved are:
- space_id | spaceId
- user_id | userId

(everything else is optional for the time being)

## Why?
Preserving of the query parameters is important as it is used to retrieve the correct session from cookies (see `getAppSession.ts` inside nuxt-base)

[JIRA: EXT-2218](https://storyblok.atlassian.net/browse/EXT-2218)

## How to test? (optional)

1. Locally, create a new page such as `/settings`
2. Open the settings page and inspect it's URL
3. See if the query parameters were correctly preserved