### PR TITLE
feat(common): add disabledMiddlewarePaths option to app.config.ts

### DIFF
--- a/space-plugins/nuxt-base/app.config.ts
+++ b/space-plugins/nuxt-base/app.config.ts
@@ -14,6 +14,7 @@ declare module '@nuxt/schema' {
 			initOauthFlowUrl: string;
 			successCallback: string;
 			errorCallback: string;
+			disabledMiddlewarePaths?: string[]; //e.g.: ['/api/endpoint']
 		};
 	}
 }

--- a/space-plugins/nuxt-base/app.config.ts
+++ b/space-plugins/nuxt-base/app.config.ts
@@ -14,7 +14,9 @@ declare module '@nuxt/schema' {
 			initOauthFlowUrl: string;
 			successCallback: string;
 			errorCallback: string;
-			disabledMiddlewarePaths?: string[]; //e.g.: ['/api/endpoint']
+			middleware?: {
+				ignoredPaths?: string[]; //e.g.: ['/api/endpoint']
+			};
 		};
 	}
 }

--- a/space-plugins/nuxt-base/server/middleware/02.auth.global.ts
+++ b/space-plugins/nuxt-base/server/middleware/02.auth.global.ts
@@ -8,7 +8,7 @@ export default defineEventHandler(async (event) => {
 	if (
 		event.path === '/401' ||
 		event.path.startsWith('/__nuxt_error') ||
-		isMiddlewareDisabled(event.path, appConfig.auth.middleware?.ignoredPaths)
+		isMiddlewareIgnored(event.path, appConfig.auth.middleware?.ignoredPaths)
 	) {
 		return;
 	}
@@ -28,8 +28,9 @@ export default defineEventHandler(async (event) => {
 	event.context.appSession = appSession;
 });
 
-const isMiddlewareDisabled = (
-	path: string,
-	disabledPaths: string[] | undefined,
+const isMiddlewareIgnored = (
+	currentPath: string,
+	ignoredPaths: string[] | undefined,
 ): boolean =>
-	Array.isArray(disabledPaths) && disabledPaths.some((p) => path.startsWith(p));
+	Array.isArray(ignoredPaths) &&
+	ignoredPaths.some((p) => currentPath.startsWith(p));

--- a/space-plugins/nuxt-base/server/middleware/02.auth.global.ts
+++ b/space-plugins/nuxt-base/server/middleware/02.auth.global.ts
@@ -1,5 +1,6 @@
 export default defineEventHandler(async (event) => {
 	const appConfig = useAppConfig();
+
 	// do not enforce authentication for oauth-related APIs
 	if (event.path.startsWith(appConfig.auth.endpointPrefix)) {
 		return;
@@ -7,7 +8,7 @@ export default defineEventHandler(async (event) => {
 	if (
 		event.path === '/401' ||
 		event.path.startsWith('/__nuxt_error') ||
-		isMiddlewareDisabled(event.path, appConfig.auth.disabledMiddlewarePaths)
+		isMiddlewareDisabled(event.path, appConfig.auth.middleware?.ignoredPaths)
 	) {
 		return;
 	}

--- a/space-plugins/nuxt-base/server/middleware/02.auth.global.ts
+++ b/space-plugins/nuxt-base/server/middleware/02.auth.global.ts
@@ -4,7 +4,11 @@ export default defineEventHandler(async (event) => {
 	if (event.path.startsWith(appConfig.auth.endpointPrefix)) {
 		return;
 	}
-	if (event.path === '/401' || event.path.startsWith('/__nuxt_error')) {
+	if (
+		event.path === '/401' ||
+		event.path.startsWith('/__nuxt_error') ||
+		isMiddlewareDisabled(event.path, appConfig.auth.disabledMiddlewarePaths)
+	) {
 		return;
 	}
 
@@ -22,3 +26,9 @@ export default defineEventHandler(async (event) => {
 
 	event.context.appSession = appSession;
 });
+
+const isMiddlewareDisabled = (
+	path: string,
+	disabledPaths: string[] | undefined,
+): boolean =>
+	Array.isArray(disabledPaths) && disabledPaths.some((p) => path.startsWith(p));


### PR DESCRIPTION
## What?
Adding new option `disabledMiddlewarePaths` to have a possibility to disable middleware for specific paths. 

## Why?

JIRA: EXT-2300

## TODO
- [x] create ticket to add information on app.config.ts (EXT-2301)


## How to test? 
1. Inside `space-plugin/nuxt-starter/nuxt.config.ts` replace the `extends` property to use the local nuxt base (`extends: [['../nuxt-base', { install: true }]]` )
2. Create a new endpoint inside the `nuxt-starter` (e.g: `api/disabled`)
3. Create a new file inside `nuxt-starter` with the file name `app.config.ts` with the following content: 
```
export default defineAppConfig({
	auth: {
		disabledMiddlewarePaths: ['api/disabled'],
	},
});

```
4. Place a console.log inside `nuxt-base/server/middleware/02.auth.global.ts` on line 11, to verify if the disabled function works correctly
5. Run `pnpm run dev`
6. Hit the `api/disabled` endpoint and observe if the console log was triggered.