### PR TITLE
docs(common): include the getting started npx command for Tool Starter

### DIFF
--- a/space-plugins/nuxt-starter/README.md
+++ b/space-plugins/nuxt-starter/README.md
@@ -19,9 +19,9 @@ This repository is developed using [pnpm](https://pnpm.io/). However, you can al
 ```sh
 cd YOUR-PROJECT-NAME
 
-pnpm install && pnpm run dev
+pnpm install && pnpm dev
 # or
-yarn install && yarn run dev
+yarn install && yarn dev
 # or
 npm install && npm run dev
 ```
@@ -63,7 +63,7 @@ Ensure that "Production" is the section that contains information about the prod
 
 <img src="./docs/install-link.png" alt="Install Link" width="600" />
 
-6. Start developing by running `yarn dev:nuxt`, and open it on Storyblok.
+6. Start developing by running `yarn dev`, and open it on Storyblok.
 
 <img src="./docs/open-extension.png" alt="Open the extension" width="200" />
 

--- a/tool-plugins/nextjs-starter/README.md
+++ b/tool-plugins/nextjs-starter/README.md
@@ -2,15 +2,23 @@
 
 This is a starter template for Storyblok tools, created with Next.js (Pages Router) and [@storyblok/app-extension-auth](https://github.com/storyblok/app-extension-auth).
 
-## How to run
-
-Install dependencies by running:
+## Getting Started
 
 ```shell
-yarn install
+npx giget@latest gh:storyblok/space-tool-plugins/tool-plugins/nextjs-starter YOUR-PROJECT-NAME
 ```
 
-Set up a secure tunnel to proxy your request to/from `localhost:3000`, for example with [ngrok](https://ngrok.com/):
+## How to run
+
+Navigate to your project folder and install dependencies by running:
+
+```shell
+cd YOUR-PROJECT-NAME
+
+yarn install # pnpm install or npm install
+```
+
+Set up a secure tunnel to proxy your request to/from `localhost:3000`, for example, with [ngrok](https://ngrok.com/):
 
 ```shell
 ngrok http 3000
@@ -18,17 +26,15 @@ ngrok http 3000
 
 Note down your assigned URL; this will be your `baseUrl` for the application.
 
-### Create new Storyblok Extension
+### Create a new Storyblok Extension
 
-There are two ways on how you can create a tool inside
-Storyblok. Depending on your plan and use case, choose
-one of the following options:
+There are two ways on how you can create a tool inside Storyblok. Depending on your plan and use case, choose one of the following options:
 
 #### Partner Portal
 
 1. Open [Storyblok's Partner Portal Extension View](https://app.storyblok.com/#/partner/apps)
 2. Click On **New Extension**
-3. Fill in the fields `name` and `slug`.
+3. Fill in the fields `name` and `slug`
 4. Select `tool` as extension type
 5. Click on **Save**
 
@@ -36,7 +42,7 @@ one of the following options:
 
 1. Open [Storyblok's Organization Extension View](https://app.storyblok.com/#/me/org/apps)
 2. Click On **New Extension**
-3. Fill in the fields `name` and `slug`.
+3. Fill in the fields `name` and `slug`
 4. Select `tool` as extension type
 5. Click on **Save**
 
@@ -44,7 +50,7 @@ one of the following options:
 
 Once the tool has been created, a new entry will appear inside the extension list. Open it and navigate to the `OAuth 2.0 and Pages` tab.
 
-Configure the following properties base on the previous steps:
+Configure the following properties based on the previous steps:
 
 - **Index to your page**: `{baseUrl}`
 - **Redirection endpoint**: `{baseUrl}/api/connect/callback`
@@ -53,15 +59,15 @@ Configure the following properties base on the previous steps:
 
 Rename the file `.env.local.example` to `.env.local`. Open the file and set the environmental variables:
 
-- `CLIENT_ID`: the client id from the tool's settings page.
+- `CLIENT_ID`: the client ID from the tool's settings page.
 - `CLIENT_SECRET`: the client secret from the tool's settings page.
 - `BASE_URL`: The `baseUrl` from your secure tunnel.
-- `NEXT_PUBLIC_TOOL_ID` the slug from the tool's settings page.
+- `NEXT_PUBLIC_TOOL_ID` is the slug from the tool's settings page.
 
 Start the application by running:
 
 ```shell
-yarn dev
+yarn dev # pnpm dev or npm run dev
 ```
 
 ### Tool Installation
@@ -71,7 +77,7 @@ Finally, install the application to your space:
 1. Navigate to the tool's settings page.
 2. Open the **General Tab**.
 3. Open the **Install Link** in a new browser tab.
-4. Select a space, the Tool Plugin should be installed to.
+4. Select a space the Tool Plugin should be installed to.
 5. Open the selected space from Step 4.
 6. Navigate to a story of your choice.
 7. Open the tool tab by clicking ![tools icon](public/tools.svg)
@@ -85,7 +91,7 @@ When deploying your Tool Plugin, please remember to adjust the tool settings ins
 
 ## Read More
 
-For more detailed information on Storyblok extensions,read the following guides:
+For more detailed information on Storyblok extensions, read the following guides:
 
 - [Tool Plugins](https://www.storyblok.com/docs/plugins/tool)
 - [OAuth 2.0 Authorization Flow](https://www.storyblok.com/docs/plugins/authentication-apps)


### PR DESCRIPTION
## What?

- Fix some bash commands
- Include a Getting Started section with the `npx command` for the Tool Starter 

## Why?

As I was following the internal onboarding and I found this useful, I wanted to add it here 💜