### PR TITLE
feat(common): include a BaseModal component and a usage example

### DIFF
--- a/space-plugins/nuxt-base-ui/.playground/app.vue
+++ b/space-plugins/nuxt-base-ui/.playground/app.vue
@@ -1,6 +1,16 @@
 <script setup lang="ts">
+// BaseAlert
 const alert = useAlert();
 alert.success('Hello, World!');
+
+// BaseModal
+const modalRef = ref<InstanceType<typeof BaseModal>>();
+const showModal = () => modalRef.value?.show();
+const closeModal = () => modalRef.value?.close();
+const onConfirm = () => {
+	// Do some action
+	closeModal();
+};
 </script>
 
 <template>
@@ -9,4 +19,30 @@ alert.success('Hello, World!');
 		:message="alert.state.message"
 		:type="alert.state.type"
 	/>
+
+	<button @click="showModal">Open Modal</button>
+	<BaseModal
+		ref="modalRef"
+		title="Are you sure?"
+		message="Would you like to continue?"
+	>
+		<template #actions>
+			<menu class="modal-action px-8 py-6 m-0 bg-gray-100">
+				<button
+					class="btn btn-tertiary"
+					title="Close the modal and cancel the action"
+					@click.prevent="closeModal"
+				>
+					Cancel
+				</button>
+				<button
+					class="btn btn-primary"
+					title="Confirm the action"
+					@click.prevent="onConfirm"
+				>
+					Confirm
+				</button>
+			</menu>
+		</template>
+	</BaseModal>
 </template>

--- a/space-plugins/nuxt-base-ui/components/BaseModal.vue
+++ b/space-plugins/nuxt-base-ui/components/BaseModal.vue
@@ -19,12 +19,16 @@ defineExpose({
 	<dialog ref="modalRef" class="modal">
 		<form method="dialog" class="modal-box p-0 rounded-lg">
 			<section class="flex flex-col gap-4 p-9 items-center">
-				<h2 v-if="title" class="font-bold text-xl">
-					{{ title }}
-				</h2>
-				<p v-if="message" class="py-4 text-ink-50 font-normal">
-					{{ message }}
-				</p>
+				<slot name="header">
+					<h2 v-if="title" class="font-bold text-xl">
+						{{ title }}
+					</h2>
+				</slot>
+				<slot name="content">
+					<p v-if="message" class="py-4 text-ink-50 font-normal">
+						{{ message }}
+					</p>
+				</slot>
 			</section>
 			<slot name="actions" />
 		</form>

--- a/space-plugins/nuxt-base-ui/components/BaseModal.vue
+++ b/space-plugins/nuxt-base-ui/components/BaseModal.vue
@@ -1,0 +1,32 @@
+<script setup lang="ts">
+defineProps<{
+	title?: string;
+	message?: string;
+}>();
+
+const modalRef = ref<HTMLDialogElement | null>(null);
+
+const show = () => modalRef.value?.showModal();
+const close = () => modalRef.value?.close();
+
+defineExpose({
+	show,
+	close,
+});
+</script>
+
+<template>
+	<dialog ref="modalRef" class="modal">
+		<form method="dialog" class="modal-box p-0 rounded-lg">
+			<section class="flex flex-col gap-4 p-9 items-center">
+				<h2 v-if="title" class="font-bold text-xl">
+					{{ title }}
+				</h2>
+				<p v-if="message" class="py-4 text-ink-50 font-normal">
+					{{ message }}
+				</p>
+			</section>
+			<slot name="actions" />
+		</form>
+	</dialog>
+</template>


### PR DESCRIPTION
## What?

This PR includes a BaseModal component to be able to reuse across Plugins.

This is how it looks:
<img width="778" alt="Screenshot 2024-05-01 at 15 56 33" src="https://github.com/storyblok/space-tool-plugins/assets/36744484/29191e9d-c0e1-4616-9544-ac6e9dbab025">

## Why?

JIRA: EXT-2901

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

## How to test? (optional)

By changing `'github:storyblok/space-tool-plugins/space-plugins/nuxt-base-ui',` with `../nuxt-base-ui` in Nuxt-Starter nuxt.config.ts file, you will be able to try out the same code at the playground with the applied styles by Daisy.

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->
