### PR TITLE
fix(common): update google fonts config to use roboto 500

### DIFF
--- a/space-plugins/nuxt-starter/nuxt.config.ts
+++ b/space-plugins/nuxt-starter/nuxt.config.ts
@@ -15,7 +15,7 @@ export default defineNuxtConfig({
 	modules: ['nuxt-lucide-icons', '@nuxtjs/google-fonts', '@nuxtjs/tailwindcss'],
 	googleFonts: {
 		families: {
-			Roboto: [300, 400, 700],
+			Roboto: [300, 400, 500, 700],
 		},
 	},
 });


### PR DESCRIPTION
## What?

This PR updates google fonts config to use roboto 500

## Why?

We've been trying to use weight 500, but it didn't work due to the lack of this configuration.