### PR TITLE
feat(common): handle NuxtError

### DIFF
--- a/space-plugins/nuxt-base-ui/plugins/base-error-handler.ts
+++ b/space-plugins/nuxt-base-ui/plugins/base-error-handler.ts
@@ -1,5 +1,6 @@
 import { FetchError } from 'ofetch';
 import type { Alert, AlertType } from '~/types/alert';
+import type { NuxtError } from 'nuxt/app';
 
 const createAlert = () => {
 	const alert = reactive<Alert>({
@@ -45,13 +46,16 @@ export default defineNuxtPlugin((nuxtApp) => {
 	const { alert, show, success, error, info, warn } = createAlert();
 
 	nuxtApp.hook('vue:error', (err: unknown) => {
+		console.error(err);
+
 		if (err instanceof FetchError) {
 			error(err.data.message);
-			return;
+		} else if (isNuxtError(err as any)) {
+			const nuxtError = err as NuxtError;
+			error(nuxtError.statusMessage || 'Unknown error');
+		} else {
+			error('Unknown error');
 		}
-
-		error('Unknown error');
-		console.error(err);
 	});
 
 	return {


### PR DESCRIPTION
## What?

In `nuxt-base-ui`, we show an alert on errors. So far we only take care of `FetchError`, but this PR adds support for `NuxtError`.

Before this PR, if you `throw createError({ statusCode: xxx, statusMessage: '...' })`, it still showed 'Unknown error'. Now it will display proper error message given from the `createError()` call.
