### PR TITLE
feat(space-nuxt-base): fix webhook error message to provide more context

### DIFF
--- a/space-plugins/nuxt-base/server/utils/webhook.ts
+++ b/space-plugins/nuxt-base/server/utils/webhook.ts
@@ -28,21 +28,22 @@ export const createStoryblokWebhook: CreateStoryblokWebhook = async (
 	const url = `${apiHost}/v1/spaces/${params.spaceId}/webhook_endpoints`;
 
 	try {
-		const result: StoryblokWebhookResponse = await $fetch(url, {
-			headers: {
-				Authorization: `Bearer ${params.accessToken}`,
-			},
-			method: 'POST',
-			body: {
-				name: params.name,
-				description: params.description,
-				endpoint: params.endpoint,
-				secret: params.secret,
-				actions: params.actions,
-				activated: params.activated ?? true,
-				isLegacy: params.isLegacy ?? false,
-			},
-		});
+		const result: StoryblokWebhookResponse =
+			await $fetch<StoryblokWebhookResponse>(url, {
+				headers: {
+					Authorization: `Bearer ${params.accessToken}`,
+				},
+				method: 'POST',
+				body: {
+					name: params.name,
+					description: params.description,
+					endpoint: params.endpoint,
+					secret: params.secret,
+					actions: params.actions,
+					activated: params.activated ?? true,
+					isLegacy: params.isLegacy ?? false,
+				},
+			});
 
 		return {
 			ok: true,
@@ -69,7 +70,7 @@ export const createStoryblokWebhook: CreateStoryblokWebhook = async (
 		}
 		return {
 			ok: false,
-			error: 'unknown',
+			error: err.data ?? 'unknown',
 		};
 	}
 };


### PR DESCRIPTION



## What?
- Fixes the problem with typescript
- If err.data is available we can pass it to the end-consumer

## Why?

While I was testing a webhook issue occurring on the community plan, the integration only received an 'unknown' error. After exploring the error object I found out that in my case error.data provided more information on why the problem is happening. That is why I believe it will be a great addition.

