### PR TITLE
feat(space-nuxt-base): remove init_oauth stale cookie deletion and move to app-extension-auth

### DIFF
--- a/space-plugins/nuxt-base/server/middleware/02.auth.global.ts
+++ b/space-plugins/nuxt-base/server/middleware/02.auth.global.ts
@@ -13,16 +13,15 @@ export default defineEventHandler(async (event) => {
 		return;
 	}
 
-	// Delete cookie and initiated OAuth flow
-	// if the user hasn't been authenticated yet.
+	// If the user hasn't been authenticated yet.
 	// (Storyfront attaches this query parameter in that case)
-	if (getQuery(event)['init_oauth'] === 'true') {
-		setCookie(event, AUTH_COOKIE_NAME, '', {
-			httpOnly: true,
-			secure: true,
-			sameSite: 'none',
-		});
-		return await sendRedirect(event, appConfig.auth.initOauthFlowUrl, 302);
+	const queryParams = getQuery(event);
+	if (queryParams['init_oauth'] === 'true') {
+		return await sendRedirect(
+			event,
+			`${appConfig.auth.initOauthFlowUrl}?init_oauth=true`,
+			302,
+		);
 	}
 
 	const appSession = await getAppSession(event);


### PR DESCRIPTION

## What?
- Removing functionality to reset the session cookie. This logic should be handled by app-extension-auth library. 
- Add forwarding of `init_oauth` query parameter.
## Why?
This problem and solution are necessary as there is no way to remove the cookies when a plugin is uninstalled. This can cause issues when a plugin is reinstalled as the old cookie is persisted. When app-extension-auth finds that there is a cookie, it will try to use it, even when it is not valid anymore.


JIRA: SHAPE-5947


This PR depends and can only be merged after [#38](https://github.com/storyblok/app-extension-auth/pull/38) is merged and a new version of app-extension-auth is released. 

