### PR TITLE
fix(space-nuxt-base): move plugin type to the top level of app config

### DIFF
--- a/space-plugins/nuxt-base/app.config.ts
+++ b/space-plugins/nuxt-base/app.config.ts
@@ -1,8 +1,8 @@
-import type { AppBridgeConfig } from './types/appBridge';
+import type { AppBridgeConfig, PluginType } from './types/appBridge';
 
 export default defineAppConfig({
+	type: 'space-plugin',
 	appBridge: {
-		type: 'space-plugin',
 		enabled: false,
 		oauth: true,
 		origin: 'https://app.storyblok.com',
@@ -17,6 +17,7 @@ export default defineAppConfig({
 
 declare module '@nuxt/schema' {
 	interface AppConfigInput {
+		type: PluginType;
 		appBridge: AppBridgeConfig;
 		auth: AuthConfig;
 	}

--- a/space-plugins/nuxt-base/composables/useAppBridge.ts
+++ b/space-plugins/nuxt-base/composables/useAppBridge.ts
@@ -96,7 +96,7 @@ const useAppBridgeAuth = ({
 		const slug = getSlug();
 
 		try {
-			const type = appConfig.appBridge.type;
+			const type = appConfig.type;
 			const payload = createValidateMessagePayload({ type, slug });
 
 			postMessageToParent(payload);
@@ -205,7 +205,7 @@ const useOAuth = () => {
 
 	const sendBeginOAuthMessageToParent = (redirectTo: string) => {
 		const slug = getSlug();
-		const type = appConfig.appBridge.type;
+		const type = appConfig.type;
 		const payload = createOAuthInitMessagePayload({ type, slug, redirectTo });
 		postMessageToParent(payload);
 	};

--- a/space-plugins/nuxt-base/server/middleware/01.handle-401.global.ts
+++ b/space-plugins/nuxt-base/server/middleware/01.handle-401.global.ts
@@ -1,11 +1,14 @@
 export default defineEventHandler(async (event) => {
+	const appConfig = useAppConfig();
 	if (
 		event.path === '/401' &&
 		event.headers.get('Referer') === 'https://app.storyblok.com/'
 	) {
 		return await sendRedirect(
 			event,
-			'https://app.storyblok.com/oauth/app_redirect',
+			appConfig.type === 'tool-plugin'
+				? 'https://app.storyblok.com/oauth/tool_redirect'
+				: 'https://app.storyblok.com/oauth/app_redirect',
 			302,
 		);
 	}

--- a/space-plugins/nuxt-base/server/middleware/04.app_session.global.ts
+++ b/space-plugins/nuxt-base/server/middleware/04.app_session.global.ts
@@ -6,6 +6,10 @@ export default defineEventHandler(async (event) => {
 	const appConfig = useAppConfig();
 
 	const appSession = await getAppSession(event);
+	if (!appSession) {
+		return;
+	}
+
 	event.context.appSession = appSession;
 
 	const afterAuthenticated = appConfig.auth.middleware?.afterAuthenticated;

--- a/space-plugins/nuxt-base/types/appBridge.ts
+++ b/space-plugins/nuxt-base/types/appBridge.ts
@@ -1,5 +1,4 @@
 export type AppBridgeConfig = {
-	type: PluginType;
 	enabled: boolean;
 	oauth: boolean;
 	origin?: string;


### PR DESCRIPTION
## What?

This PR moves the plugin type to the top level of appConfig.

## Why?

This way, we can differentiate if the project is a tool plugin or a space plugin no matter if it's using app bridge or not. It's not necessary right now, but with this, we could easily create a starter for Tool Plugins based on this nuxt-base project. Only difference between Space Plugins and Tool Plugins is that Tool Plugins should send its height to Storyfront. We can do it by updating the layout file within Tool Plugins' starter project.