### PR TITLE
fix(space-nuxt-starter): move default layout to nuxt-starter

### DIFF
--- a/space-plugins/nuxt-base/package.json
+++ b/space-plugins/nuxt-base/package.json
@@ -11,7 +11,7 @@
 		"postinstall": "nuxt prepare"
 	},
 	"dependencies": {
-		"@storyblok/app-extension-auth": "2.0.0-beta.2",
+		"@storyblok/app-extension-auth": "2.0.0",
 		"@storyblok/region-helper": "^1.1.0",
 		"jsonwebtoken": "^9.0.2"
 	},

--- a/space-plugins/nuxt-base/pnpm-lock.yaml
+++ b/space-plugins/nuxt-base/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@storyblok/app-extension-auth':
-        specifier: 2.0.0-beta.2
-        version: 2.0.0-beta.2
+        specifier: 2.0.0
+        version: 2.0.0
       '@storyblok/region-helper':
         specifier: ^1.1.0
         version: 1.1.0
@@ -859,8 +859,8 @@ packages:
     resolution: {integrity: sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==}
     engines: {node: '>=18'}
 
-  '@storyblok/app-extension-auth@2.0.0-beta.2':
-    resolution: {integrity: sha512-uXylHYiTsZgTsNnfDMFWrss/vGrbik0BHyPKmatBoJ9mWXRZyBKnGkkepccvEvI5GLHJkM2/Qm9g3hLtxcJvag==}
+  '@storyblok/app-extension-auth@2.0.0':
+    resolution: {integrity: sha512-/hosbT8IhMODRy+Rxk10hG51m4WMrhmpl4LwO3g0JtSdAS+f6/Jl0f6CFDhlZ3FD1dQb3ncZyodSUpbiXxvBlw==}
     engines: {node: '>=14.21.3'}
 
   '@storyblok/region-helper@0.1.0':
@@ -4016,7 +4016,7 @@ snapshots:
 
   '@sindresorhus/merge-streams@2.3.0': {}
 
-  '@storyblok/app-extension-auth@2.0.0-beta.2':
+  '@storyblok/app-extension-auth@2.0.0':
     dependencies:
       '@storyblok/region-helper': 0.1.0
       jsonwebtoken: 9.0.2

--- a/space-plugins/nuxt-starter/layouts/default.vue
+++ b/space-plugins/nuxt-starter/layouts/default.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 const config = useAppConfig();
 const { completed, appBridgeAuth, oauth } = useAppBridge();
-
 const nuxtApp = useNuxtApp();
 nuxtApp.provide('appBridge', {
 	completed,

--- a/space-plugins/nuxt-starter/package.json
+++ b/space-plugins/nuxt-starter/package.json
@@ -12,7 +12,7 @@
 		"postinstall": "nuxt prepare"
 	},
 	"dependencies": {
-		"@storyblok/app-extension-auth": "2.0.0-beta.2",
+		"@storyblok/app-extension-auth": "2.0.0",
 		"@storyblok/region-helper": "^1.1.0",
 		"storyblok-js-client": "^6.2.0"
 	},

--- a/space-plugins/nuxt-starter/pnpm-lock.yaml
+++ b/space-plugins/nuxt-starter/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@storyblok/app-extension-auth':
-        specifier: 2.0.0-beta.2
-        version: 2.0.0-beta.2
+        specifier: 2.0.0
+        version: 2.0.0
       '@storyblok/region-helper':
         specifier: ^1.1.0
         version: 1.1.0
@@ -945,8 +945,8 @@ packages:
     resolution: {integrity: sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==}
     engines: {node: '>=18'}
 
-  '@storyblok/app-extension-auth@2.0.0-beta.2':
-    resolution: {integrity: sha512-uXylHYiTsZgTsNnfDMFWrss/vGrbik0BHyPKmatBoJ9mWXRZyBKnGkkepccvEvI5GLHJkM2/Qm9g3hLtxcJvag==}
+  '@storyblok/app-extension-auth@2.0.0':
+    resolution: {integrity: sha512-/hosbT8IhMODRy+Rxk10hG51m4WMrhmpl4LwO3g0JtSdAS+f6/Jl0f6CFDhlZ3FD1dQb3ncZyodSUpbiXxvBlw==}
     engines: {node: '>=14.21.3'}
 
   '@storyblok/region-helper@0.1.0':
@@ -5278,7 +5278,7 @@ snapshots:
 
   '@sindresorhus/merge-streams@2.3.0': {}
 
-  '@storyblok/app-extension-auth@2.0.0-beta.2':
+  '@storyblok/app-extension-auth@2.0.0':
     dependencies:
       '@storyblok/region-helper': 0.1.0
       jsonwebtoken: 9.0.2

--- a/space-plugins/story-starter/pnpm-lock.yaml
+++ b/space-plugins/story-starter/pnpm-lock.yaml
@@ -11,8 +11,8 @@ importers:
   starters/nuxt:
     dependencies:
       '@storyblok/app-extension-auth':
-        specifier: 1.0.3
-        version: 1.0.3
+        specifier: 2.0.0
+        version: 2.0.0
       '@storyblok/region-helper':
         specifier: ^1.1.0
         version: 1.1.0
@@ -958,8 +958,8 @@ packages:
     resolution: {integrity: sha512-rUV5WyJrJLoloD4NDN1V1+LDMDWOa4OTsT4yYJwQNpTU6FWxkxHpL7eu4w+DmiH8x/EAM1otkPE1+LaspIbplw==}
     engines: {node: '>=18'}
 
-  '@storyblok/app-extension-auth@1.0.3':
-    resolution: {integrity: sha512-tSdMNn8Cj3zshuUkSlRZ7Qaf2A9TDK7SigK3susnREHY9hsPZATJVDI+8sBX+BmK3NXFMJlBnnVq/L+Rde73Ng==}
+  '@storyblok/app-extension-auth@2.0.0':
+    resolution: {integrity: sha512-/hosbT8IhMODRy+Rxk10hG51m4WMrhmpl4LwO3g0JtSdAS+f6/Jl0f6CFDhlZ3FD1dQb3ncZyodSUpbiXxvBlw==}
     engines: {node: '>=14.21.3'}
 
   '@storyblok/region-helper@0.1.0':
@@ -5275,7 +5275,7 @@ snapshots:
 
   '@sindresorhus/merge-streams@1.0.0': {}
 
-  '@storyblok/app-extension-auth@1.0.3':
+  '@storyblok/app-extension-auth@2.0.0':
     dependencies:
       '@storyblok/region-helper': 0.1.0
       jsonwebtoken: 9.0.2

--- a/space-plugins/story-starter/starters/nuxt/package.json
+++ b/space-plugins/story-starter/starters/nuxt/package.json
@@ -13,7 +13,7 @@
 		"postinstall": "nuxt prepare"
 	},
 	"dependencies": {
-		"@storyblok/app-extension-auth": "1.0.3",
+		"@storyblok/app-extension-auth": "2.0.0",
 		"@storyblok/region-helper": "^1.1.0",
 		"@types/nprogress": "^0.2.3",
 		"nprogress": "^0.2.0",


### PR DESCRIPTION
## What?

This PR moves `layouts/default.vue` from nuxt-base to nuxt-starter. If user has their own `layouts/default.vue`, then it will override the one from nuxt-base. To avoid this, we should just put the layout in the starter project, so that user can directly update the layout file as they want.
