### PR TITLE
fix(space-nuxt-base): explicitly import

### DIFF
--- a/space-plugins/nuxt-base/server/middleware/02.app_bridge.global.ts
+++ b/space-plugins/nuxt-base/server/middleware/02.app_bridge.global.ts
@@ -1,3 +1,4 @@
+import { APP_BRIDGE_TOKEN_HEADER_KEY } from '../../utils/const';
 const SKIP_AUTH_FOR = ['/api/_app_bridge', '/api/_oauth'];
 
 export default defineEventHandler(async (event) => {


### PR DESCRIPTION
## What?

Although it's correctly auto-imported, Nuxt is failing to resolve it. So let's explicitly import this.

![image](https://github.com/user-attachments/assets/a5d97d0b-dfc2-437e-80a2-08c902ebcc40)
