### PR TITLE
feat(space-nuxt-base): add appBridgeSession

### DIFF
--- a/space-plugins/nuxt-base/composables/useAppBridge.ts
+++ b/space-plugins/nuxt-base/composables/useAppBridge.ts
@@ -70,7 +70,7 @@ const useAppBridgeAuth = ({
 
 	const isAuthenticated = () => {
 		try {
-			const payload: DecodedToken = JSON.parse(
+			const payload: AppBridgeSession = JSON.parse(
 				sessionStorage.getItem(KEY_VALIDATED_PAYLOAD) || '',
 			);
 			return payload && new Date().getTime() / 1000 < payload.exp;

--- a/space-plugins/nuxt-base/index.d.ts
+++ b/space-plugins/nuxt-base/index.d.ts
@@ -2,7 +2,8 @@ import type { AppSession } from '@storyblok/app-extension-auth';
 
 declare module 'h3' {
 	interface H3EventContext {
-		appSession: AppSession;
+		appSession?: AppSession;
+		appBridgeSession?: AppBridgeSession;
 	}
 }
 

--- a/space-plugins/nuxt-base/server/middleware/02.app_bridge.global.ts
+++ b/space-plugins/nuxt-base/server/middleware/02.app_bridge.global.ts
@@ -26,4 +26,5 @@ export default defineEventHandler(async (event) => {
 	if (!result.ok) {
 		throw createError({ statusCode: 401 });
 	}
+	event.context.appBridgeSession = result.result;
 });

--- a/space-plugins/nuxt-base/server/utils/appBridge.ts
+++ b/space-plugins/nuxt-base/server/utils/appBridge.ts
@@ -13,10 +13,10 @@ export const verifyAppBridgeToken = async (
 async function verifyToken(
 	token: string,
 	secret: string,
-): Promise<DecodedToken> {
+): Promise<AppBridgeSession> {
 	return new Promise((resolve, reject) => {
 		const verifyCallback: VerifyCallback = (err, decoded) =>
-			err ? reject(err) : resolve(decoded as DecodedToken);
+			err ? reject(err) : resolve(decoded as AppBridgeSession);
 		jwt.verify(token, secret, verifyCallback);
 	});
 }

--- a/space-plugins/nuxt-base/types/appBridge.ts
+++ b/space-plugins/nuxt-base/types/appBridge.ts
@@ -5,10 +5,10 @@ export type AppBridgeConfig = {
 };
 
 export type VerifyResponse =
-	| { ok: true; result: DecodedToken }
+	| { ok: true; result: AppBridgeSession }
 	| { ok: false; error: unknown };
 
-export type DecodedToken = {
+export type AppBridgeSession = {
 	app_id: number;
 	space_id: number;
 	user_id: number;


### PR DESCRIPTION
## What?

This PR updates the app bridge middleware to add `appBridgeSession` to `event.context` when app bridge authentication is successful.

## Why?

There are ways to get spaceId on the server side. We could explicitly include spaceId in http requests but it's tedious. If we're using OAuth, we could get it via `event.context.appSession`. However, we don't have such thing for App Bridge. In case a project is using App Bridge only without OAuth, we need something like `event.context.appBridgeSession` to get the authenticated session information on the server side.