### PR TITLE
chore(tool-next, space-next): update dependencies, docs and add a CI GitHub Action for Nextjs starters

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,10 +1,10 @@
+Issue:
+
 ## What?
 
 <!-- Mention the changes that are included in the PR -->
 
 ## Why?
-
-JIRA: EXT-
 
 <!--
   Explain the **motivation** for making this change.

--- a/.github/workflows/ci-next-templates.yml
+++ b/.github/workflows/ci-next-templates.yml
@@ -1,0 +1,30 @@
+name: 'ci-next-templates'
+on:
+  push:
+    paths:
+      - 'space-plugins/nextjs-starter'
+      - 'tool-plugins/nextjs-starter'
+jobs:
+  nextjs-starters-checks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.14.0
+      - uses: pnpm/action-setup@v4
+        name: Install pnpm
+        with:
+          version: 10
+          run_install: false
+      - name: Build Space Plugin Starter
+        run: |
+          cd space-plugins/nextjs-starter
+          pnpm install
+          pnpm build
+      - name: Build Tool Plugin Starter
+        run: |
+          cd tool-plugins/nextjs-starter
+          pnpm install
+          pnpm build

--- a/.github/workflows/ci-next-templates.yml
+++ b/.github/workflows/ci-next-templates.yml
@@ -5,8 +5,12 @@ on:
       - 'space-plugins/nextjs-starter'
       - 'tool-plugins/nextjs-starter'
 jobs:
-  nextjs-starters-checks:
+  nextjs-space-plugin-starter-checks:
     runs-on: ubuntu-latest
+    name: Build Space Plugin Starter
+    defaults:
+      run:
+        working-directory: ./space-plugins/nextjs-starter
     steps:
       - uses: actions/checkout@v4
       - name: Setup node
@@ -18,13 +22,24 @@ jobs:
         with:
           version: 10
           run_install: false
+      - name: Install dependencies
+        run: pnpm install
       - name: Build Space Plugin Starter
-        run: |
-          cd space-plugins/nextjs-starter
-          pnpm install
-          pnpm build
+        run: pnpm build
+  nextjs-tool-plugin-starter-checks:
+    runs-on: ubuntu-latest
+    name: Build Tool Plugin Starter
+    defaults:
+      run:
+        working-directory: ./tool-plugins/nextjs-starter
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.14.0
+          cache: 'yarn'
+      - name: Install dependencies
+        run: yarn
       - name: Build Tool Plugin Starter
-        run: |
-          cd tool-plugins/nextjs-starter
-          pnpm install
-          pnpm build
+        run: yarn build

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Storyblok Space/Tool Plugins
 
-This repository is a collection of starters to help developers quickly start building their own Storyblok plugins.
+This repository is a collection of starters to help developers quickly start building their own Storyblok Tool plugins and Space plugins (legacy Custom Apps).
 
-> **Warning:** This repository is still considered as work in progress. While the team is actively developing and curating content to support your needs, it may not be in its final, polished state.
+> This is an active repository that will be updated whenever there is a change in the way plugins interact with the Storyblok ecosystem. You can use it as a reference for your own plugins.
 
 ## Introduction
 

--- a/space-plugins/nextjs-starter/README.md
+++ b/space-plugins/nextjs-starter/README.md
@@ -2,6 +2,8 @@
 
 This is a starter template for Storyblok Space Plugins, created with Next.js (Pages Router) and [@storyblok/app-extension-auth](https://github.com/storyblok/app-extension-auth).
 
+> WARNING: App Bridge should be activated in the Extension for this template to work.
+
 ## Getting Started
 
 ```shell
@@ -15,7 +17,7 @@ Navigate to your project folder and install dependencies by running:
 ```shell
 cd YOUR-PROJECT-NAME
 
-yarn install # pnpm install or npm install
+pnpm install # yarn install or npm install
 ```
 
 Set up a secure tunnel to proxy your request to/from `localhost:3000`, for example, with [ngrok](https://ngrok.com/):
@@ -66,7 +68,7 @@ Rename the file `.env.local.example` to `.env.local`. Open the file and set the 
 Start the application by running:
 
 ```shell
-yarn dev # pnpm dev or npm run dev
+pnpm dev # yarn dev or npm run dev
 ```
 
 ### App Bridge

--- a/space-plugins/nextjs-starter/package.json
+++ b/space-plugins/nextjs-starter/package.json
@@ -9,16 +9,16 @@
 		"lint": "next lint"
 	},
 	"dependencies": {
-		"@storyblok/app-extension-auth": "2.0.0",
+		"@storyblok/app-extension-auth": "2.0.3",
 		"jsonwebtoken": "^9.0.2",
 		"next": "13.4.19",
 		"react": "18.2.0",
 		"react-dom": "18.2.0",
-		"typescript": "5.2.2"
+		"typescript": "5.8.3"
 	},
 	"devDependencies": {
-		"@types/jsonwebtoken": "^9.0.6",
-		"@types/node": "20.5.9",
+		"@types/jsonwebtoken": "^9.0.9",
+		"@types/node": "22.14.0",
 		"@types/react": "18.2.21",
 		"@types/react-dom": "18.2.7"
 	}

--- a/space-plugins/nextjs-starter/pnpm-lock.yaml
+++ b/space-plugins/nextjs-starter/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@storyblok/app-extension-auth':
-        specifier: 2.0.0
-        version: 2.0.0
+        specifier: 2.0.3
+        version: 2.0.3
       jsonwebtoken:
         specifier: ^9.0.2
         version: 9.0.2
@@ -24,15 +24,15 @@ importers:
         specifier: 18.2.0
         version: 18.2.0(react@18.2.0)
       typescript:
-        specifier: 5.2.2
-        version: 5.2.2
+        specifier: 5.8.3
+        version: 5.8.3
     devDependencies:
       '@types/jsonwebtoken':
-        specifier: ^9.0.6
-        version: 9.0.6
+        specifier: ^9.0.9
+        version: 9.0.9
       '@types/node':
-        specifier: 20.5.9
-        version: 20.5.9
+        specifier: 22.14.0
+        version: 22.14.0
       '@types/react':
         specifier: 18.2.21
         version: 18.2.21
@@ -99,21 +99,24 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@storyblok/app-extension-auth@2.0.0':
-    resolution: {integrity: sha512-/hosbT8IhMODRy+Rxk10hG51m4WMrhmpl4LwO3g0JtSdAS+f6/Jl0f6CFDhlZ3FD1dQb3ncZyodSUpbiXxvBlw==}
+  '@storyblok/app-extension-auth@2.0.3':
+    resolution: {integrity: sha512-NXqkAb1wcjANo4fVm23cRgGIzUr3xMfVZqiTa68x2M/E10GBduvoiEdK7oR5oN6Bz4lghbA03ctF4xTlBh1MoQ==}
     engines: {node: '>=14.21.3'}
 
-  '@storyblok/region-helper@0.1.0':
-    resolution: {integrity: sha512-psDn8OrU9y1Y7qWXbUCeNQ1U+8XyumerE5MBTfN+06L/lRlR9DJ4BRWOlx/cjKF6RXd5CnUBjcg1BNM3IupIkA==}
+  '@storyblok/region-helper@1.1.0':
+    resolution: {integrity: sha512-2NU/GHeaS9vFtkZJk/mNH6E5HvrV3vT3AN/Wrl44L3lwLIfcK4E0orjgCi7gvl0N3Ul5E+y6vJAVjD3bmjSZVg==}
 
   '@swc/helpers@0.5.1':
     resolution: {integrity: sha512-sJ902EfIzn1Fa+qYmjdQqh8tPsoxyBz+8yBKC2HKUxyezKJFwPGOn7pv4WY6QuQW//ySQi5lJjA/ZT9sNWWNTg==}
 
-  '@types/jsonwebtoken@9.0.6':
-    resolution: {integrity: sha512-/5hndP5dCjloafCXns6SZyESp3Ldq7YjH3zwzwczYnjxIT0Fqzk5ROSYVGfFyczIue7IUEj8hkvLbPoLQ18vQw==}
+  '@types/jsonwebtoken@9.0.9':
+    resolution: {integrity: sha512-uoe+GxEuHbvy12OUQct2X9JenKM3qAscquYymuQN4fMWG9DBQtykrQEFcAbVACF7qaLw9BePSodUL0kquqBJpQ==}
 
-  '@types/node@20.5.9':
-    resolution: {integrity: sha512-PcGNd//40kHAS3sTlzKB9C9XL4K0sTup8nbG5lC14kzEteTNuAFh9u5nA0o5TWnSG2r/JNPRXFVcHJIIeRlmqQ==}
+  '@types/ms@2.1.0':
+    resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
+
+  '@types/node@22.14.0':
+    resolution: {integrity: sha512-Kmpl+z84ILoG+3T/zQFyAJsU6EPTmOCj8/2+83fSN6djd6I4o7uOuGIH6vq3PrjY5BGitSbFuMN18j3iknubbA==}
 
   '@types/prop-types@15.7.12':
     resolution: {integrity: sha512-5zvhXYtRNRluoE/jAp4GVsSduVUzNWKkOZrCDBWYtE7biZywwdC2AcEzg+cSMLFRfVgeAFqpfNabiPjxFddV1Q==}
@@ -228,8 +231,8 @@ packages:
     resolution: {integrity: sha512-IF4PcGgzAr6XXSff26Sk/+P4KZFJVuHAJZj3wgO3vX2bMdNVp/QXTP3P7CEm9V1IdG8lDLY3HhiqpsE/nOwpPw==}
     engines: {node: ^10.13.0 || >=12.0.0}
 
-  openid-client@5.7.0:
-    resolution: {integrity: sha512-4GCCGZt1i2kTHpwvaC/sCpTpQqDnBzDzuJcJMbH+y1Q5qI8U8RBvoSh28svarXszZHR5BAMXbJPX1PGPRE3VOA==}
+  openid-client@5.7.1:
+    resolution: {integrity: sha512-jDBPgSVfTnkIh71Hg9pRvtJc6wTwqjRkN88+gCFtYWrlP4Yx2Dsrow8uPi3qLr/aeymPF3o2+dS+wOpglK04ew==}
 
   picocolors@1.1.0:
     resolution: {integrity: sha512-TQ92mBOW0l3LeMeyLV6mzy/kWr8lkd/hp3mTg7wYK7zJhuBStmGMBG0BdeDZS/dZx1IukaX6Bk11zcln25o1Aw==}
@@ -282,10 +285,13 @@ packages:
   tslib@2.7.0:
     resolution: {integrity: sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==}
 
-  typescript@5.2.2:
-    resolution: {integrity: sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==}
+  typescript@5.8.3:
+    resolution: {integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
   watchpack@2.4.0:
     resolution: {integrity: sha512-Lcvm7MGST/4fup+ifyKi2hjyIAwcdI4HRgtvTpIUxBRhB+RFtUh8XtDOxUfctVCnhVi+QQj49i91OyvzkJl6cg==}
@@ -328,23 +334,28 @@ snapshots:
   '@next/swc-win32-x64-msvc@13.4.19':
     optional: true
 
-  '@storyblok/app-extension-auth@2.0.0':
+  '@storyblok/app-extension-auth@2.0.3':
     dependencies:
-      '@storyblok/region-helper': 0.1.0
+      '@storyblok/region-helper': 1.1.0
       jsonwebtoken: 9.0.2
-      openid-client: 5.7.0
+      openid-client: 5.7.1
 
-  '@storyblok/region-helper@0.1.0': {}
+  '@storyblok/region-helper@1.1.0': {}
 
   '@swc/helpers@0.5.1':
     dependencies:
       tslib: 2.7.0
 
-  '@types/jsonwebtoken@9.0.6':
+  '@types/jsonwebtoken@9.0.9':
     dependencies:
-      '@types/node': 20.5.9
+      '@types/ms': 2.1.0
+      '@types/node': 22.14.0
 
-  '@types/node@20.5.9': {}
+  '@types/ms@2.1.0': {}
+
+  '@types/node@22.14.0':
+    dependencies:
+      undici-types: 6.21.0
 
   '@types/prop-types@15.7.12': {}
 
@@ -464,7 +475,7 @@ snapshots:
 
   oidc-token-hash@5.0.3: {}
 
-  openid-client@5.7.0:
+  openid-client@5.7.1:
     dependencies:
       jose: 4.15.9
       lru-cache: 6.0.0
@@ -508,7 +519,9 @@ snapshots:
 
   tslib@2.7.0: {}
 
-  typescript@5.2.2: {}
+  typescript@5.8.3: {}
+
+  undici-types@6.21.0: {}
 
   watchpack@2.4.0:
     dependencies:

--- a/tool-plugins/nextjs-starter/README.md
+++ b/tool-plugins/nextjs-starter/README.md
@@ -1,6 +1,8 @@
 # Storyblok Tool Starter x Next.js
 
-This is a starter template for Storyblok tools, created with Next.js (Pages Router) and [@storyblok/app-extension-auth](https://github.com/storyblok/app-extension-auth).
+This is a starter template for Storyblok Tool plugins, created with Next.js (Pages Router) and [@storyblok/app-extension-auth](https://github.com/storyblok/app-extension-auth).
+
+> WARNING: App Bridge should be activated in the Extension for this template to work.
 
 ## Getting Started
 

--- a/tool-plugins/nextjs-starter/package.json
+++ b/tool-plugins/nextjs-starter/package.json
@@ -9,16 +9,16 @@
 		"lint": "next lint"
 	},
 	"dependencies": {
-		"@storyblok/app-extension-auth": "2.0.0",
+		"@storyblok/app-extension-auth": "2.0.3",
 		"jsonwebtoken": "^9.0.2",
 		"next": "13.4.19",
 		"react": "18.2.0",
 		"react-dom": "18.2.0",
-		"typescript": "5.2.2"
+		"typescript": "5.8.3"
 	},
 	"devDependencies": {
-		"@types/jsonwebtoken": "^9.0.7",
-		"@types/node": "20.5.9",
+		"@types/jsonwebtoken": "^9.0.9",
+		"@types/node": "22.14.0",
 		"@types/react": "18.2.21",
 		"@types/react-dom": "18.2.7"
 	},

--- a/tool-plugins/nextjs-starter/yarn.lock
+++ b/tool-plugins/nextjs-starter/yarn.lock
@@ -75,21 +75,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storyblok/app-extension-auth@npm:2.0.0":
-  version: 2.0.0
-  resolution: "@storyblok/app-extension-auth@npm:2.0.0"
+"@storyblok/app-extension-auth@npm:2.0.3":
+  version: 2.0.3
+  resolution: "@storyblok/app-extension-auth@npm:2.0.3"
   dependencies:
-    "@storyblok/region-helper": 0.1.0
+    "@storyblok/region-helper": 1.1.0
     jsonwebtoken: ^9.0.0
-    openid-client: ^5.4.2
-  checksum: 839bc19914e1a790e8d24db6d95e614aad0b21ef0919819a4e92f33f5be0fa7d21c51e4108ec47c94352d541ca4c3f48d5d615f33b617b44721f479116d82ad9
+    openid-client: ^5.7.1
+  checksum: 45f44d32a4cf6df49c052a55a8550e4587a5fc0b87bc9ee1ebc517657b9b3abbfdd3cdaa12b1ff6e5a3d321889f5bbda8d173bdbd888dd1bf5a814775118cee5
   languageName: node
   linkType: hard
 
-"@storyblok/region-helper@npm:0.1.0":
-  version: 0.1.0
-  resolution: "@storyblok/region-helper@npm:0.1.0"
-  checksum: 602eb93f1081ed6e746751c1de4b24ff3c7d4b6aeb208449f5474c0bbf780e8257c46e892919b09374364597ab93a3084f903d6c8cda6f9a07e0d3df02e08f8b
+"@storyblok/region-helper@npm:1.1.0":
+  version: 1.1.0
+  resolution: "@storyblok/region-helper@npm:1.1.0"
+  checksum: 2eca9a222a28699f858d2ca27d58016cbe164f26d5b55fdb0caa58525e2d8cadb9fafd4e8f4337e71d2a354297f41531fda7292e93b5cd26c074d444e6edecbf
   languageName: node
   linkType: hard
 
@@ -102,12 +102,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/jsonwebtoken@npm:^9.0.7":
-  version: 9.0.7
-  resolution: "@types/jsonwebtoken@npm:9.0.7"
+"@types/jsonwebtoken@npm:^9.0.9":
+  version: 9.0.9
+  resolution: "@types/jsonwebtoken@npm:9.0.9"
   dependencies:
+    "@types/ms": "*"
     "@types/node": "*"
-  checksum: 872b62e2a50ec399d695402ccddfeb5cd66a6c3d28511f27453b932b6b67eb82c2d0ecaa864939848b88b3a8276c2492647bf5707bc82a6ac7e420d3412b9047
+  checksum: 9d564fc09fc83f66e319754dee0b039ae23f28fc38a9227c35283e69311ddf5a7493a060c7f956df8cd856416747c515b51fec20b8656865eacebf23b3c6bc62
+  languageName: node
+  linkType: hard
+
+"@types/ms@npm:*":
+  version: 2.1.0
+  resolution: "@types/ms@npm:2.1.0"
+  checksum: 532d2ebb91937ccc4a89389715e5b47d4c66e708d15942fe6cc25add6dc37b2be058230a327dd50f43f89b8b6d5d52b74685a9e8f70516edfc9bdd6be910eff4
   languageName: node
   linkType: hard
 
@@ -120,10 +128,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:20.5.9":
-  version: 20.5.9
-  resolution: "@types/node@npm:20.5.9"
-  checksum: 717490e94131722144878b4ca1a963ede1673bb8f2ef78c2f5b50b918df6dc9b35e7f8283e5c2a7a9f137730f7c08dc6228e53d4494a94c9ee16881e6ce6caed
+"@types/node@npm:22.14.0":
+  version: 22.14.0
+  resolution: "@types/node@npm:22.14.0"
+  dependencies:
+    undici-types: ~6.21.0
+  checksum: 8bfae1d3c428b122d23750690bdc5b8295a53949823563ec60654a24ece98bde4fc0d2b5f06ddc6def6f01a08dfe62cece7c93e60964b74f736145dad5ee1302
   languageName: node
   linkType: hard
 
@@ -439,15 +449,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"openid-client@npm:^5.4.2":
-  version: 5.7.0
-  resolution: "openid-client@npm:5.7.0"
+"openid-client@npm:^5.7.1":
+  version: 5.7.1
+  resolution: "openid-client@npm:5.7.1"
   dependencies:
     jose: ^4.15.9
     lru-cache: ^6.0.0
     object-hash: ^2.2.0
     oidc-token-hash: ^5.0.3
-  checksum: 63fc76918fc12f3d6e1456a0b170f417defccf6820acb4581ffc226cb8c9a18d50f76f0982d7a00cce2896c732eb2a6361ad6ea04b127b2603e56408b680ef9c
+  checksum: 497aad2c8a022cef112ade19ed88fba6c8ca0e79607ebe5efdcf75c4095d7924ca479085c1c94f689f6dbc9442c61aab3c2443eb347bcbc6ef51df68827c7c47
   languageName: node
   linkType: hard
 
@@ -549,16 +559,16 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "tool-nextjs-starter@workspace:."
   dependencies:
-    "@storyblok/app-extension-auth": 2.0.0
-    "@types/jsonwebtoken": ^9.0.7
-    "@types/node": 20.5.9
+    "@storyblok/app-extension-auth": 2.0.3
+    "@types/jsonwebtoken": ^9.0.9
+    "@types/node": 22.14.0
     "@types/react": 18.2.21
     "@types/react-dom": 18.2.7
     jsonwebtoken: ^9.0.2
     next: 13.4.19
     react: 18.2.0
     react-dom: 18.2.0
-    typescript: 5.2.2
+    typescript: 5.8.3
   languageName: unknown
   linkType: soft
 
@@ -569,23 +579,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:5.2.2":
-  version: 5.2.2
-  resolution: "typescript@npm:5.2.2"
+"typescript@npm:5.8.3":
+  version: 5.8.3
+  resolution: "typescript@npm:5.8.3"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 7912821dac4d962d315c36800fe387cdc0a6298dba7ec171b350b4a6e988b51d7b8f051317786db1094bd7431d526b648aba7da8236607febb26cf5b871d2d3c
+  checksum: cb1d081c889a288b962d3c8ae18d337ad6ee88a8e81ae0103fa1fecbe923737f3ba1dbdb3e6d8b776c72bc73bfa6d8d850c0306eed1a51377d2fccdfd75d92c4
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@5.2.2#~builtin<compat/typescript>":
-  version: 5.2.2
-  resolution: "typescript@patch:typescript@npm%3A5.2.2#~builtin<compat/typescript>::version=5.2.2&hash=f3b441"
+"typescript@patch:typescript@5.8.3#~builtin<compat/typescript>":
+  version: 5.8.3
+  resolution: "typescript@patch:typescript@npm%3A5.8.3#~builtin<compat/typescript>::version=5.8.3&hash=f3b441"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 0f4da2f15e6f1245e49db15801dbee52f2bbfb267e1c39225afdab5afee1a72839cd86000e65ee9d7e4dfaff12239d28beaf5ee431357fcced15fb08583d72ca
+  checksum: 1b503525a88ff0ff5952e95870971c4fb2118c17364d60302c21935dedcd6c37e6a0a692f350892bafcef6f4a16d09073fe461158547978d2f16fbe4cb18581c
   languageName: node
   linkType: hard
 
@@ -593,6 +603,13 @@ __metadata:
   version: 6.19.8
   resolution: "undici-types@npm:6.19.8"
   checksum: de51f1b447d22571cf155dfe14ff6d12c5bdaec237c765085b439c38ca8518fc360e88c70f99469162bf2e14188a7b0bcb06e1ed2dc031042b984b0bb9544017
+  languageName: node
+  linkType: hard
+
+"undici-types@npm:~6.21.0":
+  version: 6.21.0
+  resolution: "undici-types@npm:6.21.0"
+  checksum: 46331c7d6016bf85b3e8f20c159d62f5ae471aba1eb3dc52fff35a0259d58dcc7d592d4cc4f00c5f9243fa738a11cfa48bd20203040d4a9e6bc25e807fab7ab3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Issue: SHAPE-9348

## What?

- Update `nextjs-starter` space & tool plugins dependencies (not Next or React to avoid compatibility issues).
- Improve docs details.
- Add a CI workflow for `nextjs` projects.

## Why?

To keep the templates updated and have a way for the future to check the build is not breaking during the PR review.

## How to test? (optional)

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->
