### PR TITLE
chore(common): update all instances of auth-extension + region helper to the latest version

### DIFF
--- a/space-plugins/nextjs-starter/package.json
+++ b/space-plugins/nextjs-starter/package.json
@@ -9,7 +9,7 @@
 		"lint": "next lint"
 	},
 	"dependencies": {
-		"@storyblok/app-extension-auth": "2.0.3",
+		"@storyblok/app-extension-auth": "^2.1.0",
 		"jsonwebtoken": "^9.0.2",
 		"next": "13.4.19",
 		"react": "18.2.0",

--- a/space-plugins/nextjs-starter/pnpm-lock.yaml
+++ b/space-plugins/nextjs-starter/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@storyblok/app-extension-auth':
-        specifier: 2.0.3
-        version: 2.0.3
+        specifier: ^2.1.0
+        version: 2.1.0
       jsonwebtoken:
         specifier: ^9.0.2
         version: 9.0.2
@@ -99,12 +99,12 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@storyblok/app-extension-auth@2.0.3':
-    resolution: {integrity: sha512-NXqkAb1wcjANo4fVm23cRgGIzUr3xMfVZqiTa68x2M/E10GBduvoiEdK7oR5oN6Bz4lghbA03ctF4xTlBh1MoQ==}
+  '@storyblok/app-extension-auth@2.1.0':
+    resolution: {integrity: sha512-TPk4wK3WQpkoR1NRf3wAo3iZ3H3dUi2s9EY5gz12CbwMqbCtP3jarVNERCMfojJGO36wxhvTg3aOMVakBDZDNA==}
     engines: {node: '>=14.21.3'}
 
-  '@storyblok/region-helper@1.1.0':
-    resolution: {integrity: sha512-2NU/GHeaS9vFtkZJk/mNH6E5HvrV3vT3AN/Wrl44L3lwLIfcK4E0orjgCi7gvl0N3Ul5E+y6vJAVjD3bmjSZVg==}
+  '@storyblok/region-helper@1.2.0':
+    resolution: {integrity: sha512-Ew6okkK7vQvkk/jdjaM7f6szJXYtcBmPJXhl3zzh/rW9QdAaHKOodiIbvdkpvkcOrSNmUpXcx5d2gxYL5HRIzg==}
 
   '@swc/helpers@0.5.1':
     resolution: {integrity: sha512-sJ902EfIzn1Fa+qYmjdQqh8tPsoxyBz+8yBKC2HKUxyezKJFwPGOn7pv4WY6QuQW//ySQi5lJjA/ZT9sNWWNTg==}
@@ -227,8 +227,8 @@ packages:
     resolution: {integrity: sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==}
     engines: {node: '>= 6'}
 
-  oidc-token-hash@5.0.3:
-    resolution: {integrity: sha512-IF4PcGgzAr6XXSff26Sk/+P4KZFJVuHAJZj3wgO3vX2bMdNVp/QXTP3P7CEm9V1IdG8lDLY3HhiqpsE/nOwpPw==}
+  oidc-token-hash@5.1.0:
+    resolution: {integrity: sha512-y0W+X7Ppo7oZX6eovsRkuzcSM40Bicg2JEJkDJ4irIt1wsYAP5MLSNv+QAogO8xivMffw/9OvV3um1pxXgt1uA==}
     engines: {node: ^10.13.0 || >=12.0.0}
 
   openid-client@5.7.1:
@@ -334,13 +334,13 @@ snapshots:
   '@next/swc-win32-x64-msvc@13.4.19':
     optional: true
 
-  '@storyblok/app-extension-auth@2.0.3':
+  '@storyblok/app-extension-auth@2.1.0':
     dependencies:
-      '@storyblok/region-helper': 1.1.0
+      '@storyblok/region-helper': 1.2.0
       jsonwebtoken: 9.0.2
       openid-client: 5.7.1
 
-  '@storyblok/region-helper@1.1.0': {}
+  '@storyblok/region-helper@1.2.0': {}
 
   '@swc/helpers@0.5.1':
     dependencies:
@@ -473,14 +473,14 @@ snapshots:
 
   object-hash@2.2.0: {}
 
-  oidc-token-hash@5.0.3: {}
+  oidc-token-hash@5.1.0: {}
 
   openid-client@5.7.1:
     dependencies:
       jose: 4.15.9
       lru-cache: 6.0.0
       object-hash: 2.2.0
-      oidc-token-hash: 5.0.3
+      oidc-token-hash: 5.1.0
 
   picocolors@1.1.0: {}
 

--- a/space-plugins/nuxt-base/package.json
+++ b/space-plugins/nuxt-base/package.json
@@ -11,8 +11,8 @@
 		"postinstall": "nuxt prepare"
 	},
 	"dependencies": {
-		"@storyblok/app-extension-auth": "2.0.0",
-		"@storyblok/region-helper": "^1.1.0",
+		"@storyblok/app-extension-auth": "^2.1.0",
+		"@storyblok/region-helper": "^1.2.0",
 		"jsonwebtoken": "^9.0.2"
 	},
 	"devDependencies": {

--- a/space-plugins/nuxt-base/pnpm-lock.yaml
+++ b/space-plugins/nuxt-base/pnpm-lock.yaml
@@ -9,11 +9,11 @@ importers:
   .:
     dependencies:
       '@storyblok/app-extension-auth':
-        specifier: 2.0.0
-        version: 2.0.0
+        specifier: ^2.1.0
+        version: 2.1.0
       '@storyblok/region-helper':
-        specifier: ^1.1.0
-        version: 1.1.0
+        specifier: ^1.2.0
+        version: 1.2.0
       jsonwebtoken:
         specifier: ^9.0.2
         version: 9.0.2
@@ -862,15 +862,12 @@ packages:
     resolution: {integrity: sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==}
     engines: {node: '>=18'}
 
-  '@storyblok/app-extension-auth@2.0.0':
-    resolution: {integrity: sha512-/hosbT8IhMODRy+Rxk10hG51m4WMrhmpl4LwO3g0JtSdAS+f6/Jl0f6CFDhlZ3FD1dQb3ncZyodSUpbiXxvBlw==}
+  '@storyblok/app-extension-auth@2.1.0':
+    resolution: {integrity: sha512-TPk4wK3WQpkoR1NRf3wAo3iZ3H3dUi2s9EY5gz12CbwMqbCtP3jarVNERCMfojJGO36wxhvTg3aOMVakBDZDNA==}
     engines: {node: '>=14.21.3'}
 
-  '@storyblok/region-helper@0.1.0':
-    resolution: {integrity: sha512-psDn8OrU9y1Y7qWXbUCeNQ1U+8XyumerE5MBTfN+06L/lRlR9DJ4BRWOlx/cjKF6RXd5CnUBjcg1BNM3IupIkA==}
-
-  '@storyblok/region-helper@1.1.0':
-    resolution: {integrity: sha512-2NU/GHeaS9vFtkZJk/mNH6E5HvrV3vT3AN/Wrl44L3lwLIfcK4E0orjgCi7gvl0N3Ul5E+y6vJAVjD3bmjSZVg==}
+  '@storyblok/region-helper@1.2.0':
+    resolution: {integrity: sha512-Ew6okkK7vQvkk/jdjaM7f6szJXYtcBmPJXhl3zzh/rW9QdAaHKOodiIbvdkpvkcOrSNmUpXcx5d2gxYL5HRIzg==}
 
   '@trysound/sax@0.2.0':
     resolution: {integrity: sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==}
@@ -2205,8 +2202,8 @@ packages:
   ohash@1.1.3:
     resolution: {integrity: sha512-zuHHiGTYTA1sYJ/wZN+t5HKZaH23i4yI1HMwbuXm24Nid7Dv0KcuRlKoNKS9UNfAVSBlnGLcuQrnOKWOZoEGaw==}
 
-  oidc-token-hash@5.0.3:
-    resolution: {integrity: sha512-IF4PcGgzAr6XXSff26Sk/+P4KZFJVuHAJZj3wgO3vX2bMdNVp/QXTP3P7CEm9V1IdG8lDLY3HhiqpsE/nOwpPw==}
+  oidc-token-hash@5.1.0:
+    resolution: {integrity: sha512-y0W+X7Ppo7oZX6eovsRkuzcSM40Bicg2JEJkDJ4irIt1wsYAP5MLSNv+QAogO8xivMffw/9OvV3um1pxXgt1uA==}
     engines: {node: ^10.13.0 || >=12.0.0}
 
   on-finished@2.4.1:
@@ -2232,8 +2229,8 @@ packages:
     resolution: {integrity: sha512-c/hfooPx+RBIOPM09GSxABOZhYPblDoyaGhqBkD/59vtpN21jEuWKDlM0KYTvqJVlSYjKs0tBcIdeXKChlSPtw==}
     hasBin: true
 
-  openid-client@5.6.5:
-    resolution: {integrity: sha512-5P4qO9nGJzB5PI0LFlhj4Dzg3m4odt0qsJTfyEtZyOlkgpILwEioOhVVJOrS1iVH494S4Ee5OCjjg6Bf5WOj3w==}
+  openid-client@5.7.1:
+    resolution: {integrity: sha512-jDBPgSVfTnkIh71Hg9pRvtJc6wTwqjRkN88+gCFtYWrlP4Yx2Dsrow8uPi3qLr/aeymPF3o2+dS+wOpglK04ew==}
 
   package-json-from-dist@1.0.0:
     resolution: {integrity: sha512-dATvCeZN/8wQsGywez1mzHtTlP22H8OEfPrVMLNr4/eGa+ijtLn/6M5f0dY8UKNrC2O9UCU6SSoG3qRKnt7STw==}
@@ -4019,15 +4016,13 @@ snapshots:
 
   '@sindresorhus/merge-streams@2.3.0': {}
 
-  '@storyblok/app-extension-auth@2.0.0':
+  '@storyblok/app-extension-auth@2.1.0':
     dependencies:
-      '@storyblok/region-helper': 0.1.0
+      '@storyblok/region-helper': 1.2.0
       jsonwebtoken: 9.0.2
-      openid-client: 5.6.5
+      openid-client: 5.7.1
 
-  '@storyblok/region-helper@0.1.0': {}
-
-  '@storyblok/region-helper@1.1.0': {}
+  '@storyblok/region-helper@1.2.0': {}
 
   '@trysound/sax@0.2.0': {}
 
@@ -5599,7 +5594,7 @@ snapshots:
 
   ohash@1.1.3: {}
 
-  oidc-token-hash@5.0.3: {}
+  oidc-token-hash@5.1.0: {}
 
   on-finished@2.4.1:
     dependencies:
@@ -5635,12 +5630,12 @@ snapshots:
       undici: 5.28.4
       yargs-parser: 21.1.1
 
-  openid-client@5.6.5:
+  openid-client@5.7.1:
     dependencies:
       jose: 4.15.9
       lru-cache: 6.0.0
       object-hash: 2.2.0
-      oidc-token-hash: 5.0.3
+      oidc-token-hash: 5.1.0
 
   package-json-from-dist@1.0.0: {}
 

--- a/space-plugins/nuxt-starter/package.json
+++ b/space-plugins/nuxt-starter/package.json
@@ -12,8 +12,8 @@
 		"postinstall": "nuxt prepare"
 	},
 	"dependencies": {
-		"@storyblok/app-extension-auth": "2.0.0",
-		"@storyblok/region-helper": "^1.1.0",
+		"@storyblok/app-extension-auth": "^2.1.0",
+		"@storyblok/region-helper": "^1.2.0",
 		"storyblok-js-client": "^6.2.0"
 	},
 	"devDependencies": {

--- a/space-plugins/nuxt-starter/pnpm-lock.yaml
+++ b/space-plugins/nuxt-starter/pnpm-lock.yaml
@@ -9,11 +9,11 @@ importers:
   .:
     dependencies:
       '@storyblok/app-extension-auth':
-        specifier: 2.0.0
-        version: 2.0.0
+        specifier: ^2.1.0
+        version: 2.1.0
       '@storyblok/region-helper':
-        specifier: ^1.1.0
-        version: 1.1.0
+        specifier: ^1.2.0
+        version: 1.2.0
       storyblok-js-client:
         specifier: ^6.2.0
         version: 6.2.0
@@ -945,15 +945,12 @@ packages:
     resolution: {integrity: sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==}
     engines: {node: '>=18'}
 
-  '@storyblok/app-extension-auth@2.0.0':
-    resolution: {integrity: sha512-/hosbT8IhMODRy+Rxk10hG51m4WMrhmpl4LwO3g0JtSdAS+f6/Jl0f6CFDhlZ3FD1dQb3ncZyodSUpbiXxvBlw==}
+  '@storyblok/app-extension-auth@2.1.0':
+    resolution: {integrity: sha512-TPk4wK3WQpkoR1NRf3wAo3iZ3H3dUi2s9EY5gz12CbwMqbCtP3jarVNERCMfojJGO36wxhvTg3aOMVakBDZDNA==}
     engines: {node: '>=14.21.3'}
 
-  '@storyblok/region-helper@0.1.0':
-    resolution: {integrity: sha512-psDn8OrU9y1Y7qWXbUCeNQ1U+8XyumerE5MBTfN+06L/lRlR9DJ4BRWOlx/cjKF6RXd5CnUBjcg1BNM3IupIkA==}
-
-  '@storyblok/region-helper@1.1.0':
-    resolution: {integrity: sha512-2NU/GHeaS9vFtkZJk/mNH6E5HvrV3vT3AN/Wrl44L3lwLIfcK4E0orjgCi7gvl0N3Ul5E+y6vJAVjD3bmjSZVg==}
+  '@storyblok/region-helper@1.2.0':
+    resolution: {integrity: sha512-Ew6okkK7vQvkk/jdjaM7f6szJXYtcBmPJXhl3zzh/rW9QdAaHKOodiIbvdkpvkcOrSNmUpXcx5d2gxYL5HRIzg==}
 
   '@trysound/sax@0.2.0':
     resolution: {integrity: sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==}
@@ -2413,8 +2410,8 @@ packages:
     resolution: {integrity: sha512-gFqAIbuKyyso/3G2qhiO2OM6shY6EPP/R0+mkDbyspxKazh8BXDC5FiFsUjlczgdNz/vfra0da2y+aHrusLG/Q==}
     hasBin: true
 
-  jose@4.15.4:
-    resolution: {integrity: sha512-W+oqK4H+r5sITxfxpSU+MMdr/YSWGvgZMQDIsNoBDGGy4i7GBPTtvFKibQzW06n3U3TqHjhvBJsirShsEJ6eeQ==}
+  jose@4.15.9:
+    resolution: {integrity: sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -2463,8 +2460,8 @@ packages:
     resolution: {integrity: sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==}
     engines: {node: '>=12', npm: '>=6'}
 
-  jwa@1.4.1:
-    resolution: {integrity: sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==}
+  jwa@1.4.2:
+    resolution: {integrity: sha512-eeH5JO+21J78qMvTIDdBXidBd6nG2kZjg5Ohz/1fpa28Z4CcsWUzJ1ZZyFq/3z3N17aZy+ZuBoHljASbL1WfOw==}
 
   jws@3.2.2:
     resolution: {integrity: sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==}
@@ -2950,8 +2947,8 @@ packages:
   ohash@1.1.3:
     resolution: {integrity: sha512-zuHHiGTYTA1sYJ/wZN+t5HKZaH23i4yI1HMwbuXm24Nid7Dv0KcuRlKoNKS9UNfAVSBlnGLcuQrnOKWOZoEGaw==}
 
-  oidc-token-hash@5.0.3:
-    resolution: {integrity: sha512-IF4PcGgzAr6XXSff26Sk/+P4KZFJVuHAJZj3wgO3vX2bMdNVp/QXTP3P7CEm9V1IdG8lDLY3HhiqpsE/nOwpPw==}
+  oidc-token-hash@5.1.0:
+    resolution: {integrity: sha512-y0W+X7Ppo7oZX6eovsRkuzcSM40Bicg2JEJkDJ4irIt1wsYAP5MLSNv+QAogO8xivMffw/9OvV3um1pxXgt1uA==}
     engines: {node: ^10.13.0 || >=12.0.0}
 
   on-finished@2.4.1:
@@ -2984,8 +2981,8 @@ packages:
     resolution: {integrity: sha512-c/hfooPx+RBIOPM09GSxABOZhYPblDoyaGhqBkD/59vtpN21jEuWKDlM0KYTvqJVlSYjKs0tBcIdeXKChlSPtw==}
     hasBin: true
 
-  openid-client@5.6.4:
-    resolution: {integrity: sha512-T1h3B10BRPKfcObdBklX639tVz+xh34O7GjofqrqiAQdm7eHsQ00ih18x6wuJ/E6FxdtS2u3FmUGPDeEcMwzNA==}
+  openid-client@5.7.1:
+    resolution: {integrity: sha512-jDBPgSVfTnkIh71Hg9pRvtJc6wTwqjRkN88+gCFtYWrlP4Yx2Dsrow8uPi3qLr/aeymPF3o2+dS+wOpglK04ew==}
 
   optionator@0.9.3:
     resolution: {integrity: sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==}
@@ -5278,15 +5275,13 @@ snapshots:
 
   '@sindresorhus/merge-streams@2.3.0': {}
 
-  '@storyblok/app-extension-auth@2.0.0':
+  '@storyblok/app-extension-auth@2.1.0':
     dependencies:
-      '@storyblok/region-helper': 0.1.0
+      '@storyblok/region-helper': 1.2.0
       jsonwebtoken: 9.0.2
-      openid-client: 5.6.4
+      openid-client: 5.7.1
 
-  '@storyblok/region-helper@0.1.0': {}
-
-  '@storyblok/region-helper@1.1.0': {}
+  '@storyblok/region-helper@1.2.0': {}
 
   '@trysound/sax@0.2.0': {}
 
@@ -6942,7 +6937,7 @@ snapshots:
 
   jiti@1.21.0: {}
 
-  jose@4.15.4: {}
+  jose@4.15.9: {}
 
   js-tokens@4.0.0: {}
 
@@ -6987,7 +6982,7 @@ snapshots:
       ms: 2.1.3
       semver: 7.6.2
 
-  jwa@1.4.1:
+  jwa@1.4.2:
     dependencies:
       buffer-equal-constant-time: 1.0.1
       ecdsa-sig-formatter: 1.0.11
@@ -6995,7 +6990,7 @@ snapshots:
 
   jws@3.2.2:
     dependencies:
-      jwa: 1.4.1
+      jwa: 1.4.2
       safe-buffer: 5.2.1
 
   keygrip@1.1.0:
@@ -7685,7 +7680,7 @@ snapshots:
 
   ohash@1.1.3: {}
 
-  oidc-token-hash@5.0.3: {}
+  oidc-token-hash@5.1.0: {}
 
   on-finished@2.4.1:
     dependencies:
@@ -7728,12 +7723,12 @@ snapshots:
       undici: 5.28.4
       yargs-parser: 21.1.1
 
-  openid-client@5.6.4:
+  openid-client@5.7.1:
     dependencies:
-      jose: 4.15.4
+      jose: 4.15.9
       lru-cache: 6.0.0
       object-hash: 2.2.0
-      oidc-token-hash: 5.0.3
+      oidc-token-hash: 5.1.0
 
   optionator@0.9.3:
     dependencies:

--- a/space-plugins/nuxt-story-starter/package.json
+++ b/space-plugins/nuxt-story-starter/package.json
@@ -13,8 +13,8 @@
 		"postinstall": "nuxt prepare"
 	},
 	"dependencies": {
-		"@storyblok/app-extension-auth": "2.0.0",
-		"@storyblok/region-helper": "^1.1.0",
+		"@storyblok/app-extension-auth": "^2.1.0",
+		"@storyblok/region-helper": "^1.2.0",
 		"@types/nprogress": "^0.2.3",
 		"nprogress": "^0.2.0",
 		"storyblok-js-client": "^6.2.0",

--- a/space-plugins/nuxt-story-starter/pnpm-lock.yaml
+++ b/space-plugins/nuxt-story-starter/pnpm-lock.yaml
@@ -9,11 +9,11 @@ importers:
   .:
     dependencies:
       '@storyblok/app-extension-auth':
-        specifier: 2.0.0
-        version: 2.0.0
+        specifier: ^2.1.0
+        version: 2.1.0
       '@storyblok/region-helper':
-        specifier: ^1.1.0
-        version: 1.1.0
+        specifier: ^1.2.0
+        version: 1.2.0
       '@types/nprogress':
         specifier: ^0.2.3
         version: 0.2.3
@@ -61,8 +61,8 @@ importers:
         specifier: 3.11.1
         version: 3.11.1(@parcel/watcher@2.4.1)(@types/node@20.10.3)(encoding@0.1.13)(eslint@8.57.0)(ioredis@5.4.1)(magicast@0.3.4)(optionator@0.9.4)(rollup@4.20.0)(terser@5.25.0)(typescript@5.5.4)(vite@5.4.0(@types/node@20.10.3)(terser@5.25.0))
       nuxt-lucide-icons:
-        specifier: 1.0.3
-        version: 1.0.3(rollup@4.20.0)(vue@3.4.37(typescript@5.5.4))
+        specifier: 1.0.5
+        version: 1.0.5(magicast@0.3.4)(rollup@4.20.0)(vue@3.4.37(typescript@5.5.4))
       vue:
         specifier: ^3.4.14
         version: 3.4.37(typescript@5.5.4)
@@ -1060,15 +1060,12 @@ packages:
     resolution: {integrity: sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==}
     engines: {node: '>=18'}
 
-  '@storyblok/app-extension-auth@2.0.0':
-    resolution: {integrity: sha512-/hosbT8IhMODRy+Rxk10hG51m4WMrhmpl4LwO3g0JtSdAS+f6/Jl0f6CFDhlZ3FD1dQb3ncZyodSUpbiXxvBlw==}
+  '@storyblok/app-extension-auth@2.1.0':
+    resolution: {integrity: sha512-TPk4wK3WQpkoR1NRf3wAo3iZ3H3dUi2s9EY5gz12CbwMqbCtP3jarVNERCMfojJGO36wxhvTg3aOMVakBDZDNA==}
     engines: {node: '>=14.21.3'}
 
-  '@storyblok/region-helper@0.1.0':
-    resolution: {integrity: sha512-psDn8OrU9y1Y7qWXbUCeNQ1U+8XyumerE5MBTfN+06L/lRlR9DJ4BRWOlx/cjKF6RXd5CnUBjcg1BNM3IupIkA==}
-
-  '@storyblok/region-helper@1.1.0':
-    resolution: {integrity: sha512-2NU/GHeaS9vFtkZJk/mNH6E5HvrV3vT3AN/Wrl44L3lwLIfcK4E0orjgCi7gvl0N3Ul5E+y6vJAVjD3bmjSZVg==}
+  '@storyblok/region-helper@1.2.0':
+    resolution: {integrity: sha512-Ew6okkK7vQvkk/jdjaM7f6szJXYtcBmPJXhl3zzh/rW9QdAaHKOodiIbvdkpvkcOrSNmUpXcx5d2gxYL5HRIzg==}
 
   '@trysound/sax@0.2.0':
     resolution: {integrity: sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==}
@@ -2555,8 +2552,8 @@ packages:
   just-debounce-it@3.2.0:
     resolution: {integrity: sha512-WXzwLL0745uNuedrCsCs3rpmfD6DBaf7uuVwaq98/8dafURfgQaBsSpjiPp5+CW6Vjltwy9cOGI6qE71b3T8iQ==}
 
-  jwa@1.4.1:
-    resolution: {integrity: sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==}
+  jwa@1.4.2:
+    resolution: {integrity: sha512-eeH5JO+21J78qMvTIDdBXidBd6nG2kZjg5Ohz/1fpa28Z4CcsWUzJ1ZZyFq/3z3N17aZy+ZuBoHljASbL1WfOw==}
 
   jws@3.2.2:
     resolution: {integrity: sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==}
@@ -2933,8 +2930,8 @@ packages:
     engines: {node: ^16.10.0 || >=18.0.0}
     hasBin: true
 
-  nuxt-lucide-icons@1.0.3:
-    resolution: {integrity: sha512-AqFYKu9+Uz3SGelg9VQt7wkm7hN2RlLwVBkRnEqKxNNWGw7zcdud3tqb63A1gfjWK5RkdBscFcrcQKvcq0bt6w==}
+  nuxt-lucide-icons@1.0.5:
+    resolution: {integrity: sha512-Mq9lFnPZu9VoIRPxbayGEyxpso9GpccJS3dqI88oiyrcXI6ZA/Qi+jHSKvYmmbZccZGyroxRQlfa58tGN5SmLw==}
 
   nuxt@3.11.1:
     resolution: {integrity: sha512-CsncE1dxP0cmOYT+PBdjMD0bOK8eZizG5tgNWUOJAAAtU45sO38maoBumYYL2kUpT/SC/dMP+831DAcVPvi9pQ==}
@@ -2975,8 +2972,8 @@ packages:
   ohash@1.1.3:
     resolution: {integrity: sha512-zuHHiGTYTA1sYJ/wZN+t5HKZaH23i4yI1HMwbuXm24Nid7Dv0KcuRlKoNKS9UNfAVSBlnGLcuQrnOKWOZoEGaw==}
 
-  oidc-token-hash@5.0.3:
-    resolution: {integrity: sha512-IF4PcGgzAr6XXSff26Sk/+P4KZFJVuHAJZj3wgO3vX2bMdNVp/QXTP3P7CEm9V1IdG8lDLY3HhiqpsE/nOwpPw==}
+  oidc-token-hash@5.1.0:
+    resolution: {integrity: sha512-y0W+X7Ppo7oZX6eovsRkuzcSM40Bicg2JEJkDJ4irIt1wsYAP5MLSNv+QAogO8xivMffw/9OvV3um1pxXgt1uA==}
     engines: {node: ^10.13.0 || >=12.0.0}
 
   on-finished@2.4.1:
@@ -3009,8 +3006,8 @@ packages:
     resolution: {integrity: sha512-c/hfooPx+RBIOPM09GSxABOZhYPblDoyaGhqBkD/59vtpN21jEuWKDlM0KYTvqJVlSYjKs0tBcIdeXKChlSPtw==}
     hasBin: true
 
-  openid-client@5.6.5:
-    resolution: {integrity: sha512-5P4qO9nGJzB5PI0LFlhj4Dzg3m4odt0qsJTfyEtZyOlkgpILwEioOhVVJOrS1iVH494S4Ee5OCjjg6Bf5WOj3w==}
+  openid-client@5.7.1:
+    resolution: {integrity: sha512-jDBPgSVfTnkIh71Hg9pRvtJc6wTwqjRkN88+gCFtYWrlP4Yx2Dsrow8uPi3qLr/aeymPF3o2+dS+wOpglK04ew==}
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -3477,9 +3474,6 @@ packages:
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
-
-  scule@1.1.1:
-    resolution: {integrity: sha512-sHtm/SsIK9BUBI3EFT/Gnp9VoKfY6QLvlkvAE6YK7454IF8FSgJEAnJpVdSC7K5/pjI5NfxhzBLW2JAfYA/shQ==}
 
   scule@1.3.0:
     resolution: {integrity: sha512-6FtHJEvt+pVMIB9IBY+IcCJ6Z5f1iQnytgyfKMhDKgmzYG+TeH/wx1y3l27rshSbLiSanrR9ffZDrEsmjlQF2g==}
@@ -4945,9 +4939,9 @@ snapshots:
       jiti: 1.21.0
       knitwork: 1.0.0
       mlly: 1.4.2
-      pathe: 1.1.1
+      pathe: 1.1.2
       pkg-types: 1.0.3
-      scule: 1.1.1
+      scule: 1.3.0
       semver: 7.5.4
       ufo: 1.3.2
       unctx: 2.3.1
@@ -4998,9 +4992,9 @@ snapshots:
       consola: 3.2.3
       defu: 6.1.3
       hookable: 5.5.3
-      pathe: 1.1.1
+      pathe: 1.1.2
       pkg-types: 1.0.3
-      scule: 1.1.1
+      scule: 1.3.0
       std-env: 3.6.0
       ufo: 1.3.2
       unimport: 3.6.0(rollup@4.20.0)
@@ -5011,7 +5005,7 @@ snapshots:
 
   '@nuxt/telemetry@2.5.3(magicast@0.3.4)(rollup@4.20.0)':
     dependencies:
-      '@nuxt/kit': 3.11.1(magicast@0.3.4)(rollup@4.20.0)
+      '@nuxt/kit': 3.12.4(magicast@0.3.4)(rollup@4.20.0)
       ci-info: 4.0.0
       consola: 3.2.3
       create-require: 1.1.1
@@ -5321,15 +5315,13 @@ snapshots:
 
   '@sindresorhus/merge-streams@2.3.0': {}
 
-  '@storyblok/app-extension-auth@2.0.0':
+  '@storyblok/app-extension-auth@2.1.0':
     dependencies:
-      '@storyblok/region-helper': 0.1.0
+      '@storyblok/region-helper': 1.2.0
       jsonwebtoken: 9.0.2
-      openid-client: 5.6.5
+      openid-client: 5.7.1
 
-  '@storyblok/region-helper@0.1.0': {}
-
-  '@storyblok/region-helper@1.1.0': {}
+  '@storyblok/region-helper@1.2.0': {}
 
   '@trysound/sax@0.2.0': {}
 
@@ -5899,7 +5891,7 @@ snapshots:
       jiti: 1.21.0
       mlly: 1.4.2
       ohash: 1.1.3
-      pathe: 1.1.1
+      pathe: 1.1.2
       perfect-debounce: 1.0.0
       pkg-types: 1.0.3
       rc9: 2.1.1
@@ -6627,7 +6619,7 @@ snapshots:
       https-proxy-agent: 7.0.2
       mri: 1.2.0
       node-fetch-native: 1.4.1
-      pathe: 1.1.1
+      pathe: 1.1.2
       tar: 6.2.0
     transitivePeerDependencies:
       - supports-color
@@ -7012,11 +7004,11 @@ snapshots:
       lodash.isstring: 4.0.1
       lodash.once: 4.1.1
       ms: 2.1.3
-      semver: 7.5.4
+      semver: 7.6.3
 
   just-debounce-it@3.2.0: {}
 
-  jwa@1.4.1:
+  jwa@1.4.2:
     dependencies:
       buffer-equal-constant-time: 1.0.1
       ecdsa-sig-formatter: 1.0.11
@@ -7024,7 +7016,7 @@ snapshots:
 
   jws@3.2.2:
     dependencies:
-      jwa: 1.4.1
+      jwa: 1.4.2
       safe-buffer: 5.2.1
 
   keygrip@1.1.0:
@@ -7459,13 +7451,14 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
-  nuxt-lucide-icons@1.0.3(rollup@4.20.0)(vue@3.4.37(typescript@5.5.4)):
+  nuxt-lucide-icons@1.0.5(magicast@0.3.4)(rollup@4.20.0)(vue@3.4.37(typescript@5.5.4)):
     dependencies:
-      '@nuxt/kit': 3.8.2(rollup@4.20.0)
+      '@nuxt/kit': 3.12.4(magicast@0.3.4)(rollup@4.20.0)
       lucide-vue-next: 0.427.0(vue@3.4.37(typescript@5.5.4))
-      pathe: 1.1.1
-      scule: 1.1.1
+      pathe: 1.1.2
+      scule: 1.3.0
     transitivePeerDependencies:
+      - magicast
       - rollup
       - supports-color
       - vue
@@ -7602,7 +7595,7 @@ snapshots:
 
   ohash@1.1.3: {}
 
-  oidc-token-hash@5.0.3: {}
+  oidc-token-hash@5.1.0: {}
 
   on-finished@2.4.1:
     dependencies:
@@ -7645,12 +7638,12 @@ snapshots:
       undici: 5.28.4
       yargs-parser: 21.1.1
 
-  openid-client@5.6.5:
+  openid-client@5.7.1:
     dependencies:
       jose: 4.15.9
       lru-cache: 6.0.0
       object-hash: 2.2.0
-      oidc-token-hash: 5.0.3
+      oidc-token-hash: 5.1.0
 
   optionator@0.9.4:
     dependencies:
@@ -8106,8 +8099,6 @@ snapshots:
   safer-buffer@2.1.2:
     optional: true
 
-  scule@1.1.1: {}
-
   scule@1.3.0: {}
 
   semver@6.3.1: {}
@@ -8499,9 +8490,9 @@ snapshots:
       local-pkg: 0.5.0
       magic-string: 0.30.5
       mlly: 1.4.2
-      pathe: 1.1.1
+      pathe: 1.1.2
       pkg-types: 1.0.3
-      scule: 1.1.1
+      scule: 1.3.0
       strip-literal: 1.3.0
       unplugin: 1.5.1
     transitivePeerDependencies:
@@ -8575,7 +8566,7 @@ snapshots:
       defu: 6.1.3
       jiti: 1.21.0
       mri: 1.2.0
-      scule: 1.1.1
+      scule: 1.3.0
     transitivePeerDependencies:
       - supports-color
 

--- a/tool-plugins/nextjs-starter/package.json
+++ b/tool-plugins/nextjs-starter/package.json
@@ -9,7 +9,7 @@
 		"lint": "next lint"
 	},
 	"dependencies": {
-		"@storyblok/app-extension-auth": "2.0.3",
+		"@storyblok/app-extension-auth": "^2.1.0",
 		"jsonwebtoken": "^9.0.2",
 		"next": "13.4.19",
 		"react": "18.2.0",

--- a/tool-plugins/nextjs-starter/yarn.lock
+++ b/tool-plugins/nextjs-starter/yarn.lock
@@ -75,21 +75,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storyblok/app-extension-auth@npm:2.0.3":
-  version: 2.0.3
-  resolution: "@storyblok/app-extension-auth@npm:2.0.3"
+"@storyblok/app-extension-auth@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "@storyblok/app-extension-auth@npm:2.1.0"
   dependencies:
-    "@storyblok/region-helper": 1.1.0
+    "@storyblok/region-helper": ^1.2.0
     jsonwebtoken: ^9.0.0
     openid-client: ^5.7.1
-  checksum: 45f44d32a4cf6df49c052a55a8550e4587a5fc0b87bc9ee1ebc517657b9b3abbfdd3cdaa12b1ff6e5a3d321889f5bbda8d173bdbd888dd1bf5a814775118cee5
+  checksum: 0d8c078c0a57089584ddf976d28dcdb4e470929cc1d477e1c003c7a987a548617c95bb0f29b99a530a5b5c8c4a940780c368df80436abcac8601bca8812709a1
   languageName: node
   linkType: hard
 
-"@storyblok/region-helper@npm:1.1.0":
-  version: 1.1.0
-  resolution: "@storyblok/region-helper@npm:1.1.0"
-  checksum: 2eca9a222a28699f858d2ca27d58016cbe164f26d5b55fdb0caa58525e2d8cadb9fafd4e8f4337e71d2a354297f41531fda7292e93b5cd26c074d444e6edecbf
+"@storyblok/region-helper@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "@storyblok/region-helper@npm:1.2.0"
+  checksum: 11c01eccc42e4d69edfe070f654be7b4756e2679df8f31ff9d6e3d2602208ed2b37ae93f64c107dbcdea6d6a6b76691e2a00b0a31335d0085926392e36a7d5b4
   languageName: node
   linkType: hard
 
@@ -443,9 +443,9 @@ __metadata:
   linkType: hard
 
 "oidc-token-hash@npm:^5.0.3":
-  version: 5.0.3
-  resolution: "oidc-token-hash@npm:5.0.3"
-  checksum: 35fa19aea9ff2c509029ec569d74b778c8a215b92bd5e6e9bc4ebbd7ab035f44304ff02430a6397c3fb7c1d15ebfa467807ca0bcd31d06ba610b47798287d303
+  version: 5.1.0
+  resolution: "oidc-token-hash@npm:5.1.0"
+  checksum: b1ac3bf07315b1e26a8a33da714d1adee58f4aa488a5680cee49adb58e3b7fd7b00be5acca86d93215de1ce1a7d53720cbc7eba8347124f251703ede3abdbcb6
   languageName: node
   linkType: hard
 
@@ -559,7 +559,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "tool-nextjs-starter@workspace:."
   dependencies:
-    "@storyblok/app-extension-auth": 2.0.3
+    "@storyblok/app-extension-auth": ^2.1.0
     "@types/jsonwebtoken": ^9.0.9
     "@types/node": 22.14.0
     "@types/react": 18.2.21

--- a/tool-plugins/nuxt-starter/package.json
+++ b/tool-plugins/nuxt-starter/package.json
@@ -12,8 +12,8 @@
 		"postinstall": "nuxt prepare"
 	},
 	"dependencies": {
-		"@storyblok/app-extension-auth": "2.0.0",
-		"@storyblok/region-helper": "^1.1.0",
+		"@storyblok/app-extension-auth": "^2.1.0",
+		"@storyblok/region-helper": "^1.2.0",
 		"storyblok-js-client": "^6.2.0"
 	},
 	"devDependencies": {

--- a/tool-plugins/nuxt-starter/pnpm-lock.yaml
+++ b/tool-plugins/nuxt-starter/pnpm-lock.yaml
@@ -9,11 +9,11 @@ importers:
   .:
     dependencies:
       '@storyblok/app-extension-auth':
-        specifier: 2.0.0
-        version: 2.0.0
+        specifier: ^2.1.0
+        version: 2.1.0
       '@storyblok/region-helper':
-        specifier: ^1.1.0
-        version: 1.1.0
+        specifier: ^1.2.0
+        version: 1.2.0
       storyblok-js-client:
         specifier: ^6.2.0
         version: 6.8.1
@@ -920,15 +920,12 @@ packages:
     resolution: {integrity: sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==}
     engines: {node: '>=18'}
 
-  '@storyblok/app-extension-auth@2.0.0':
-    resolution: {integrity: sha512-/hosbT8IhMODRy+Rxk10hG51m4WMrhmpl4LwO3g0JtSdAS+f6/Jl0f6CFDhlZ3FD1dQb3ncZyodSUpbiXxvBlw==}
+  '@storyblok/app-extension-auth@2.1.0':
+    resolution: {integrity: sha512-TPk4wK3WQpkoR1NRf3wAo3iZ3H3dUi2s9EY5gz12CbwMqbCtP3jarVNERCMfojJGO36wxhvTg3aOMVakBDZDNA==}
     engines: {node: '>=14.21.3'}
 
-  '@storyblok/region-helper@0.1.0':
-    resolution: {integrity: sha512-psDn8OrU9y1Y7qWXbUCeNQ1U+8XyumerE5MBTfN+06L/lRlR9DJ4BRWOlx/cjKF6RXd5CnUBjcg1BNM3IupIkA==}
-
-  '@storyblok/region-helper@1.1.0':
-    resolution: {integrity: sha512-2NU/GHeaS9vFtkZJk/mNH6E5HvrV3vT3AN/Wrl44L3lwLIfcK4E0orjgCi7gvl0N3Ul5E+y6vJAVjD3bmjSZVg==}
+  '@storyblok/region-helper@1.2.0':
+    resolution: {integrity: sha512-Ew6okkK7vQvkk/jdjaM7f6szJXYtcBmPJXhl3zzh/rW9QdAaHKOodiIbvdkpvkcOrSNmUpXcx5d2gxYL5HRIzg==}
 
   '@trysound/sax@0.2.0':
     resolution: {integrity: sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==}
@@ -2295,8 +2292,8 @@ packages:
     resolution: {integrity: sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==}
     engines: {node: '>=12', npm: '>=6'}
 
-  jwa@1.4.1:
-    resolution: {integrity: sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==}
+  jwa@1.4.2:
+    resolution: {integrity: sha512-eeH5JO+21J78qMvTIDdBXidBd6nG2kZjg5Ohz/1fpa28Z4CcsWUzJ1ZZyFq/3z3N17aZy+ZuBoHljASbL1WfOw==}
 
   jws@3.2.2:
     resolution: {integrity: sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==}
@@ -2693,8 +2690,8 @@ packages:
   ohash@1.1.3:
     resolution: {integrity: sha512-zuHHiGTYTA1sYJ/wZN+t5HKZaH23i4yI1HMwbuXm24Nid7Dv0KcuRlKoNKS9UNfAVSBlnGLcuQrnOKWOZoEGaw==}
 
-  oidc-token-hash@5.0.3:
-    resolution: {integrity: sha512-IF4PcGgzAr6XXSff26Sk/+P4KZFJVuHAJZj3wgO3vX2bMdNVp/QXTP3P7CEm9V1IdG8lDLY3HhiqpsE/nOwpPw==}
+  oidc-token-hash@5.1.0:
+    resolution: {integrity: sha512-y0W+X7Ppo7oZX6eovsRkuzcSM40Bicg2JEJkDJ4irIt1wsYAP5MLSNv+QAogO8xivMffw/9OvV3um1pxXgt1uA==}
     engines: {node: ^10.13.0 || >=12.0.0}
 
   on-finished@2.4.1:
@@ -2727,8 +2724,8 @@ packages:
     resolution: {integrity: sha512-c/hfooPx+RBIOPM09GSxABOZhYPblDoyaGhqBkD/59vtpN21jEuWKDlM0KYTvqJVlSYjKs0tBcIdeXKChlSPtw==}
     hasBin: true
 
-  openid-client@5.6.5:
-    resolution: {integrity: sha512-5P4qO9nGJzB5PI0LFlhj4Dzg3m4odt0qsJTfyEtZyOlkgpILwEioOhVVJOrS1iVH494S4Ee5OCjjg6Bf5WOj3w==}
+  openid-client@5.7.1:
+    resolution: {integrity: sha512-jDBPgSVfTnkIh71Hg9pRvtJc6wTwqjRkN88+gCFtYWrlP4Yx2Dsrow8uPi3qLr/aeymPF3o2+dS+wOpglK04ew==}
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -4789,15 +4786,13 @@ snapshots:
 
   '@sindresorhus/merge-streams@2.3.0': {}
 
-  '@storyblok/app-extension-auth@2.0.0':
+  '@storyblok/app-extension-auth@2.1.0':
     dependencies:
-      '@storyblok/region-helper': 0.1.0
+      '@storyblok/region-helper': 1.2.0
       jsonwebtoken: 9.0.2
-      openid-client: 5.6.5
+      openid-client: 5.7.1
 
-  '@storyblok/region-helper@0.1.0': {}
-
-  '@storyblok/region-helper@1.1.0': {}
+  '@storyblok/region-helper@1.2.0': {}
 
   '@trysound/sax@0.2.0': {}
 
@@ -6325,7 +6320,7 @@ snapshots:
       ms: 2.1.3
       semver: 7.6.3
 
-  jwa@1.4.1:
+  jwa@1.4.2:
     dependencies:
       buffer-equal-constant-time: 1.0.1
       ecdsa-sig-formatter: 1.0.11
@@ -6333,7 +6328,7 @@ snapshots:
 
   jws@3.2.2:
     dependencies:
-      jwa: 1.4.1
+      jwa: 1.4.2
       safe-buffer: 5.2.1
 
   keygrip@1.1.0:
@@ -6886,7 +6881,7 @@ snapshots:
 
   ohash@1.1.3: {}
 
-  oidc-token-hash@5.0.3: {}
+  oidc-token-hash@5.1.0: {}
 
   on-finished@2.4.1:
     dependencies:
@@ -6929,12 +6924,12 @@ snapshots:
       undici: 5.28.4
       yargs-parser: 21.1.1
 
-  openid-client@5.6.5:
+  openid-client@5.7.1:
     dependencies:
       jose: 4.15.9
       lru-cache: 6.0.0
       object-hash: 2.2.0
-      oidc-token-hash: 5.0.3
+      oidc-token-hash: 5.1.0
 
   optionator@0.9.4:
     dependencies:


### PR DESCRIPTION
## What?

Jira ticket: [SHAPE-9631](https://storyblok.atlassian.net/browse/SHAPE-9631)

It updates the [region-helper](https://www.npmjs.com/package/@storyblok/region-helper) and [app-extension-auth](https://www.npmjs.com/package/@storyblok/app-extension-auth) packages to their latest version.

## Why?

So it is ready to work with the new [SpaceId](https://github.com/storyblok/region-helper/pull/18) (using BigInt) when it is fully released.

## How to test? (optional)

If you need an example of how to test plugins locally, please go to this PR, where I added a new doc about it => https://github.com/storyblok/storyfront/pull/7570


[SHAPE-9631]: https://storyblok.atlassian.net/browse/SHAPE-9631?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ