### PR TITLE
fix(space-nuxt-base): webhook limit reached handling

### DIFF
--- a/space-plugins/nuxt-base/server/middleware/02.app_bridge.global.ts
+++ b/space-plugins/nuxt-base/server/middleware/02.app_bridge.global.ts
@@ -7,12 +7,21 @@ export default defineEventHandler(async (event) => {
 		return;
 	}
 	const pathname = event.path.split('?')[0];
+
 	if (!pathname.startsWith('/api/')) {
 		return;
 	}
-	if (SKIP_AUTH_FOR.includes(pathname)) {
+
+	const shouldIgnorePath =
+		Array.isArray(appConfig.auth.middleware?.ignoredPaths) &&
+		appConfig.auth.middleware?.ignoredPaths.some((p: string) =>
+			pathname.startsWith(p),
+		);
+
+	if (SKIP_AUTH_FOR.includes(pathname) || shouldIgnorePath) {
 		return;
 	}
+
 	if (
 		[
 			appConfig.auth.initOauthFlowUrl,

--- a/space-plugins/nuxt-base/server/utils/webhook.ts
+++ b/space-plugins/nuxt-base/server/utils/webhook.ts
@@ -153,7 +153,9 @@ const upsertStoryblokWebhook: UpsertStoryblokWebhook = async (
 	} catch (err: any) {
 		if (
 			err.status === 422 &&
-			err.data?.base?.includes('Webhook limit exceeded')
+			err.data?.base?.some((errMessage: string) =>
+				errMessage.includes('reached the maximum number of webhooks'),
+			)
 		) {
 			return {
 				ok: false,


### PR DESCRIPTION
Issue: SHAPE-10323, SHAPE-9203

## What?

- Change the webhook limit-exceed error checking. 

![Screenshot 2025-06-17 at 22 23 38](https://github.com/user-attachments/assets/68218b35-1c4b-4791-bcbe-e0403ec52e65)

- Skip App bridge for routes configured in the [ignoredPaths](https://github.com/storyblok/space-tool-plugins/blob/cf6a1e654a37c43b21949906fee3bd25dbed54df/space-plugins/nuxt-base/utils/authConfig.ts#L13).

## Why?

So it better logs the error and provides more insights to the users, and avoids breaking API calls that don't require the user to be authenticated.

## How to test? (optional)
