### PR TITLE
chore(common): update the region-helper and app-extension-auth libraries

### DIFF
--- a/space-plugins/nextjs-starter/package.json
+++ b/space-plugins/nextjs-starter/package.json
@@ -9,7 +9,7 @@
 		"lint": "next lint"
 	},
 	"dependencies": {
-		"@storyblok/app-extension-auth": "^2.1.0",
+		"@storyblok/app-extension-auth": "^2.2.1",
 		"jsonwebtoken": "^9.0.2",
 		"next": "13.4.19",
 		"react": "18.2.0",

--- a/space-plugins/nextjs-starter/pnpm-lock.yaml
+++ b/space-plugins/nextjs-starter/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@storyblok/app-extension-auth':
-        specifier: ^2.1.0
-        version: 2.1.0
+        specifier: ^2.2.1
+        version: 2.2.1
       jsonwebtoken:
         specifier: ^9.0.2
         version: 9.0.2
@@ -99,12 +99,12 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@storyblok/app-extension-auth@2.1.0':
-    resolution: {integrity: sha512-TPk4wK3WQpkoR1NRf3wAo3iZ3H3dUi2s9EY5gz12CbwMqbCtP3jarVNERCMfojJGO36wxhvTg3aOMVakBDZDNA==}
+  '@storyblok/app-extension-auth@2.2.1':
+    resolution: {integrity: sha512-zc8fRY/gsuAETRD4joY8IvC52/mDt2d4BRW9w54N56hRm9q9C6pSHXVWaKgcGrS47XuzoRsUy9i2TzGF6LKBoA==}
     engines: {node: '>=14.21.3'}
 
-  '@storyblok/region-helper@1.2.0':
-    resolution: {integrity: sha512-Ew6okkK7vQvkk/jdjaM7f6szJXYtcBmPJXhl3zzh/rW9QdAaHKOodiIbvdkpvkcOrSNmUpXcx5d2gxYL5HRIzg==}
+  '@storyblok/region-helper@1.3.0':
+    resolution: {integrity: sha512-yzjeUApGbGGsSLdnFLWN3U53YgOslVuwgak/bZZ5bT0pFlseVcb9HNd9WgzgvWHqXrAW55fXayisQ//qnsCxYw==}
 
   '@swc/helpers@0.5.1':
     resolution: {integrity: sha512-sJ902EfIzn1Fa+qYmjdQqh8tPsoxyBz+8yBKC2HKUxyezKJFwPGOn7pv4WY6QuQW//ySQi5lJjA/ZT9sNWWNTg==}
@@ -334,13 +334,13 @@ snapshots:
   '@next/swc-win32-x64-msvc@13.4.19':
     optional: true
 
-  '@storyblok/app-extension-auth@2.1.0':
+  '@storyblok/app-extension-auth@2.2.1':
     dependencies:
-      '@storyblok/region-helper': 1.2.0
+      '@storyblok/region-helper': 1.3.0
       jsonwebtoken: 9.0.2
       openid-client: 5.7.1
 
-  '@storyblok/region-helper@1.2.0': {}
+  '@storyblok/region-helper@1.3.0': {}
 
   '@swc/helpers@0.5.1':
     dependencies:

--- a/space-plugins/nuxt-base/package.json
+++ b/space-plugins/nuxt-base/package.json
@@ -11,8 +11,8 @@
 		"postinstall": "nuxt prepare"
 	},
 	"dependencies": {
-		"@storyblok/app-extension-auth": "^2.1.0",
-		"@storyblok/region-helper": "^1.2.0",
+		"@storyblok/app-extension-auth": "^2.2.1",
+		"@storyblok/region-helper": "^1.3.0",
 		"jsonwebtoken": "^9.0.2"
 	},
 	"devDependencies": {

--- a/space-plugins/nuxt-base/pnpm-lock.yaml
+++ b/space-plugins/nuxt-base/pnpm-lock.yaml
@@ -9,11 +9,11 @@ importers:
   .:
     dependencies:
       '@storyblok/app-extension-auth':
-        specifier: ^2.1.0
-        version: 2.1.0
+        specifier: ^2.2.1
+        version: 2.2.1
       '@storyblok/region-helper':
-        specifier: ^1.2.0
-        version: 1.2.0
+        specifier: ^1.3.0
+        version: 1.3.0
       jsonwebtoken:
         specifier: ^9.0.2
         version: 9.0.2
@@ -862,12 +862,12 @@ packages:
     resolution: {integrity: sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==}
     engines: {node: '>=18'}
 
-  '@storyblok/app-extension-auth@2.1.0':
-    resolution: {integrity: sha512-TPk4wK3WQpkoR1NRf3wAo3iZ3H3dUi2s9EY5gz12CbwMqbCtP3jarVNERCMfojJGO36wxhvTg3aOMVakBDZDNA==}
+  '@storyblok/app-extension-auth@2.2.1':
+    resolution: {integrity: sha512-zc8fRY/gsuAETRD4joY8IvC52/mDt2d4BRW9w54N56hRm9q9C6pSHXVWaKgcGrS47XuzoRsUy9i2TzGF6LKBoA==}
     engines: {node: '>=14.21.3'}
 
-  '@storyblok/region-helper@1.2.0':
-    resolution: {integrity: sha512-Ew6okkK7vQvkk/jdjaM7f6szJXYtcBmPJXhl3zzh/rW9QdAaHKOodiIbvdkpvkcOrSNmUpXcx5d2gxYL5HRIzg==}
+  '@storyblok/region-helper@1.3.0':
+    resolution: {integrity: sha512-yzjeUApGbGGsSLdnFLWN3U53YgOslVuwgak/bZZ5bT0pFlseVcb9HNd9WgzgvWHqXrAW55fXayisQ//qnsCxYw==}
 
   '@trysound/sax@0.2.0':
     resolution: {integrity: sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==}
@@ -4016,13 +4016,13 @@ snapshots:
 
   '@sindresorhus/merge-streams@2.3.0': {}
 
-  '@storyblok/app-extension-auth@2.1.0':
+  '@storyblok/app-extension-auth@2.2.1':
     dependencies:
-      '@storyblok/region-helper': 1.2.0
+      '@storyblok/region-helper': 1.3.0
       jsonwebtoken: 9.0.2
       openid-client: 5.7.1
 
-  '@storyblok/region-helper@1.2.0': {}
+  '@storyblok/region-helper@1.3.0': {}
 
   '@trysound/sax@0.2.0': {}
 

--- a/space-plugins/nuxt-starter/package.json
+++ b/space-plugins/nuxt-starter/package.json
@@ -12,8 +12,8 @@
 		"postinstall": "nuxt prepare"
 	},
 	"dependencies": {
-		"@storyblok/app-extension-auth": "^2.1.0",
-		"@storyblok/region-helper": "^1.2.0",
+		"@storyblok/app-extension-auth": "^2.2.1",
+		"@storyblok/region-helper": "^1.3.0",
 		"storyblok-js-client": "^6.2.0"
 	},
 	"devDependencies": {

--- a/space-plugins/nuxt-starter/pnpm-lock.yaml
+++ b/space-plugins/nuxt-starter/pnpm-lock.yaml
@@ -9,11 +9,11 @@ importers:
   .:
     dependencies:
       '@storyblok/app-extension-auth':
-        specifier: ^2.1.0
-        version: 2.1.0
+        specifier: ^2.2.1
+        version: 2.2.1
       '@storyblok/region-helper':
-        specifier: ^1.2.0
-        version: 1.2.0
+        specifier: ^1.3.0
+        version: 1.3.0
       storyblok-js-client:
         specifier: ^6.2.0
         version: 6.2.0
@@ -29,10 +29,10 @@ importers:
         version: 6.11.0(rollup@4.18.0)
       autoprefixer:
         specifier: 10.4.16
-        version: 10.4.16(postcss@8.4.38)
+        version: 10.4.16(postcss@8.4.33)
       daisyui:
         specifier: ^4.4.19
-        version: 4.4.19(postcss@8.4.38)
+        version: 4.4.19(postcss@8.4.33)
       eslint:
         specifier: ^8.56.0
         version: 8.56.0
@@ -945,12 +945,12 @@ packages:
     resolution: {integrity: sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==}
     engines: {node: '>=18'}
 
-  '@storyblok/app-extension-auth@2.1.0':
-    resolution: {integrity: sha512-TPk4wK3WQpkoR1NRf3wAo3iZ3H3dUi2s9EY5gz12CbwMqbCtP3jarVNERCMfojJGO36wxhvTg3aOMVakBDZDNA==}
+  '@storyblok/app-extension-auth@2.2.1':
+    resolution: {integrity: sha512-zc8fRY/gsuAETRD4joY8IvC52/mDt2d4BRW9w54N56hRm9q9C6pSHXVWaKgcGrS47XuzoRsUy9i2TzGF6LKBoA==}
     engines: {node: '>=14.21.3'}
 
-  '@storyblok/region-helper@1.2.0':
-    resolution: {integrity: sha512-Ew6okkK7vQvkk/jdjaM7f6szJXYtcBmPJXhl3zzh/rW9QdAaHKOodiIbvdkpvkcOrSNmUpXcx5d2gxYL5HRIzg==}
+  '@storyblok/region-helper@1.3.0':
+    resolution: {integrity: sha512-yzjeUApGbGGsSLdnFLWN3U53YgOslVuwgak/bZZ5bT0pFlseVcb9HNd9WgzgvWHqXrAW55fXayisQ//qnsCxYw==}
 
   '@trysound/sax@0.2.0':
     resolution: {integrity: sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==}
@@ -5275,13 +5275,13 @@ snapshots:
 
   '@sindresorhus/merge-streams@2.3.0': {}
 
-  '@storyblok/app-extension-auth@2.1.0':
+  '@storyblok/app-extension-auth@2.2.1':
     dependencies:
-      '@storyblok/region-helper': 1.2.0
+      '@storyblok/region-helper': 1.3.0
       jsonwebtoken: 9.0.2
       openid-client: 5.7.1
 
-  '@storyblok/region-helper@1.2.0': {}
+  '@storyblok/region-helper@1.3.0': {}
 
   '@trysound/sax@0.2.0': {}
 
@@ -5750,14 +5750,14 @@ snapshots:
 
   at-least-node@1.0.0: {}
 
-  autoprefixer@10.4.16(postcss@8.4.38):
+  autoprefixer@10.4.16(postcss@8.4.33):
     dependencies:
       browserslist: 4.22.3
       caniuse-lite: 1.0.30001581
       fraction.js: 4.3.7
       normalize-range: 0.1.2
       picocolors: 1.0.0
-      postcss: 8.4.38
+      postcss: 8.4.33
       postcss-value-parser: 4.2.0
 
   autoprefixer@10.4.17(postcss@8.4.33):
@@ -6153,12 +6153,12 @@ snapshots:
 
   culori@3.3.0: {}
 
-  daisyui@4.4.19(postcss@8.4.38):
+  daisyui@4.4.19(postcss@8.4.33):
     dependencies:
       css-selector-tokenizer: 0.8.0
       culori: 3.3.0
       picocolors: 1.0.0
-      postcss-js: 4.0.1(postcss@8.4.38)
+      postcss-js: 4.0.1(postcss@8.4.33)
     transitivePeerDependencies:
       - postcss
 
@@ -7906,11 +7906,6 @@ snapshots:
     dependencies:
       camelcase-css: 2.0.1
       postcss: 8.4.33
-
-  postcss-js@4.0.1(postcss@8.4.38):
-    dependencies:
-      camelcase-css: 2.0.1
-      postcss: 8.4.38
 
   postcss-load-config@4.0.2(postcss@8.4.33):
     dependencies:

--- a/space-plugins/nuxt-story-starter/package.json
+++ b/space-plugins/nuxt-story-starter/package.json
@@ -13,8 +13,8 @@
 		"postinstall": "nuxt prepare"
 	},
 	"dependencies": {
-		"@storyblok/app-extension-auth": "^2.1.0",
-		"@storyblok/region-helper": "^1.2.0",
+		"@storyblok/app-extension-auth": "^2.2.1",
+		"@storyblok/region-helper": "^1.3.0",
 		"@types/nprogress": "^0.2.3",
 		"nprogress": "^0.2.0",
 		"storyblok-js-client": "^6.2.0",

--- a/space-plugins/nuxt-story-starter/pnpm-lock.yaml
+++ b/space-plugins/nuxt-story-starter/pnpm-lock.yaml
@@ -9,11 +9,11 @@ importers:
   .:
     dependencies:
       '@storyblok/app-extension-auth':
-        specifier: ^2.1.0
-        version: 2.1.0
+        specifier: ^2.2.1
+        version: 2.2.1
       '@storyblok/region-helper':
-        specifier: ^1.2.0
-        version: 1.2.0
+        specifier: ^1.3.0
+        version: 1.3.0
       '@types/nprogress':
         specifier: ^0.2.3
         version: 0.2.3
@@ -1060,12 +1060,12 @@ packages:
     resolution: {integrity: sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==}
     engines: {node: '>=18'}
 
-  '@storyblok/app-extension-auth@2.1.0':
-    resolution: {integrity: sha512-TPk4wK3WQpkoR1NRf3wAo3iZ3H3dUi2s9EY5gz12CbwMqbCtP3jarVNERCMfojJGO36wxhvTg3aOMVakBDZDNA==}
+  '@storyblok/app-extension-auth@2.2.1':
+    resolution: {integrity: sha512-zc8fRY/gsuAETRD4joY8IvC52/mDt2d4BRW9w54N56hRm9q9C6pSHXVWaKgcGrS47XuzoRsUy9i2TzGF6LKBoA==}
     engines: {node: '>=14.21.3'}
 
-  '@storyblok/region-helper@1.2.0':
-    resolution: {integrity: sha512-Ew6okkK7vQvkk/jdjaM7f6szJXYtcBmPJXhl3zzh/rW9QdAaHKOodiIbvdkpvkcOrSNmUpXcx5d2gxYL5HRIzg==}
+  '@storyblok/region-helper@1.3.0':
+    resolution: {integrity: sha512-yzjeUApGbGGsSLdnFLWN3U53YgOslVuwgak/bZZ5bT0pFlseVcb9HNd9WgzgvWHqXrAW55fXayisQ//qnsCxYw==}
 
   '@trysound/sax@0.2.0':
     resolution: {integrity: sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==}
@@ -5315,13 +5315,13 @@ snapshots:
 
   '@sindresorhus/merge-streams@2.3.0': {}
 
-  '@storyblok/app-extension-auth@2.1.0':
+  '@storyblok/app-extension-auth@2.2.1':
     dependencies:
-      '@storyblok/region-helper': 1.2.0
+      '@storyblok/region-helper': 1.3.0
       jsonwebtoken: 9.0.2
       openid-client: 5.7.1
 
-  '@storyblok/region-helper@1.2.0': {}
+  '@storyblok/region-helper@1.3.0': {}
 
   '@trysound/sax@0.2.0': {}
 

--- a/tool-plugins/nextjs-starter/package.json
+++ b/tool-plugins/nextjs-starter/package.json
@@ -9,7 +9,7 @@
 		"lint": "next lint"
 	},
 	"dependencies": {
-		"@storyblok/app-extension-auth": "^2.1.0",
+		"@storyblok/app-extension-auth": "^2.2.1",
 		"jsonwebtoken": "^9.0.2",
 		"next": "13.4.19",
 		"react": "18.2.0",

--- a/tool-plugins/nextjs-starter/yarn.lock
+++ b/tool-plugins/nextjs-starter/yarn.lock
@@ -75,21 +75,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storyblok/app-extension-auth@npm:^2.1.0":
-  version: 2.1.0
-  resolution: "@storyblok/app-extension-auth@npm:2.1.0"
+"@storyblok/app-extension-auth@npm:^2.2.1":
+  version: 2.2.1
+  resolution: "@storyblok/app-extension-auth@npm:2.2.1"
   dependencies:
-    "@storyblok/region-helper": ^1.2.0
+    "@storyblok/region-helper": ^1.3.0
     jsonwebtoken: ^9.0.0
     openid-client: ^5.7.1
-  checksum: 0d8c078c0a57089584ddf976d28dcdb4e470929cc1d477e1c003c7a987a548617c95bb0f29b99a530a5b5c8c4a940780c368df80436abcac8601bca8812709a1
+  checksum: c046f0d2bebdde25f47741904feab058373c846483c0c6c2e7361318b239ba9fcaf64517e9b540a3d9b9e72e781e81d0a5c2718138ab8e15ef111d4da8cf74dd
   languageName: node
   linkType: hard
 
-"@storyblok/region-helper@npm:^1.2.0":
-  version: 1.2.0
-  resolution: "@storyblok/region-helper@npm:1.2.0"
-  checksum: 11c01eccc42e4d69edfe070f654be7b4756e2679df8f31ff9d6e3d2602208ed2b37ae93f64c107dbcdea6d6a6b76691e2a00b0a31335d0085926392e36a7d5b4
+"@storyblok/region-helper@npm:^1.3.0":
+  version: 1.3.0
+  resolution: "@storyblok/region-helper@npm:1.3.0"
+  checksum: ce52d3d9122fb8cf8b3712187e61110cbb9a1c95955a9290c07a8c785206a74f4a063ec40b741fc3346e9e0510d40610c06c06005e7fb14edeec66f2cf619dc8
   languageName: node
   linkType: hard
 
@@ -559,7 +559,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "tool-nextjs-starter@workspace:."
   dependencies:
-    "@storyblok/app-extension-auth": ^2.1.0
+    "@storyblok/app-extension-auth": ^2.2.1
     "@types/jsonwebtoken": ^9.0.9
     "@types/node": 22.14.0
     "@types/react": 18.2.21

--- a/tool-plugins/nuxt-starter/package.json
+++ b/tool-plugins/nuxt-starter/package.json
@@ -12,8 +12,8 @@
 		"postinstall": "nuxt prepare"
 	},
 	"dependencies": {
-		"@storyblok/app-extension-auth": "^2.1.0",
-		"@storyblok/region-helper": "^1.2.0",
+		"@storyblok/app-extension-auth": "^2.2.1",
+		"@storyblok/region-helper": "^1.3.0",
 		"storyblok-js-client": "^6.2.0"
 	},
 	"devDependencies": {

--- a/tool-plugins/nuxt-starter/pnpm-lock.yaml
+++ b/tool-plugins/nuxt-starter/pnpm-lock.yaml
@@ -9,11 +9,11 @@ importers:
   .:
     dependencies:
       '@storyblok/app-extension-auth':
-        specifier: ^2.1.0
-        version: 2.1.0
+        specifier: ^2.2.1
+        version: 2.2.1
       '@storyblok/region-helper':
-        specifier: ^1.2.0
-        version: 1.2.0
+        specifier: ^1.3.0
+        version: 1.3.0
       storyblok-js-client:
         specifier: ^6.2.0
         version: 6.8.1
@@ -920,12 +920,12 @@ packages:
     resolution: {integrity: sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==}
     engines: {node: '>=18'}
 
-  '@storyblok/app-extension-auth@2.1.0':
-    resolution: {integrity: sha512-TPk4wK3WQpkoR1NRf3wAo3iZ3H3dUi2s9EY5gz12CbwMqbCtP3jarVNERCMfojJGO36wxhvTg3aOMVakBDZDNA==}
+  '@storyblok/app-extension-auth@2.2.1':
+    resolution: {integrity: sha512-zc8fRY/gsuAETRD4joY8IvC52/mDt2d4BRW9w54N56hRm9q9C6pSHXVWaKgcGrS47XuzoRsUy9i2TzGF6LKBoA==}
     engines: {node: '>=14.21.3'}
 
-  '@storyblok/region-helper@1.2.0':
-    resolution: {integrity: sha512-Ew6okkK7vQvkk/jdjaM7f6szJXYtcBmPJXhl3zzh/rW9QdAaHKOodiIbvdkpvkcOrSNmUpXcx5d2gxYL5HRIzg==}
+  '@storyblok/region-helper@1.3.0':
+    resolution: {integrity: sha512-yzjeUApGbGGsSLdnFLWN3U53YgOslVuwgak/bZZ5bT0pFlseVcb9HNd9WgzgvWHqXrAW55fXayisQ//qnsCxYw==}
 
   '@trysound/sax@0.2.0':
     resolution: {integrity: sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==}
@@ -4786,13 +4786,13 @@ snapshots:
 
   '@sindresorhus/merge-streams@2.3.0': {}
 
-  '@storyblok/app-extension-auth@2.1.0':
+  '@storyblok/app-extension-auth@2.2.1':
     dependencies:
-      '@storyblok/region-helper': 1.2.0
+      '@storyblok/region-helper': 1.3.0
       jsonwebtoken: 9.0.2
       openid-client: 5.7.1
 
-  '@storyblok/region-helper@1.2.0': {}
+  '@storyblok/region-helper@1.3.0': {}
 
   '@trysound/sax@0.2.0': {}
 


### PR DESCRIPTION
Issue: SHAPE-10699

## What?

It updates the version of the [region-helper](https://www.npmjs.com/package/@storyblok/region-helper) and [app-extension-auth](https://www.npmjs.com/package/@storyblok/app-extension-auth) packages to `1.3.0` and `2.2.1` respectively.

PS: Only Nuxt starters use the `region-helper` package, the others made in Next doesn't rely on that one.